### PR TITLE
fix: include md5 in file_item to fix 0B file download

### DIFF
--- a/src/cdn/upload.ts
+++ b/src/cdn/upload.ts
@@ -21,6 +21,8 @@ export type UploadedFileInfo = {
   fileSize: number;
   /** Ciphertext file size in bytes (AES-128-ECB with PKCS7 padding); use for ImageItem.hd_size / mid_size */
   fileSizeCiphertext: number;
+  /** Plaintext file MD5 hex string; required by WeChat client for file integrity verification */
+  fileMd5: string;
 };
 
 /**
@@ -107,6 +109,7 @@ async function uploadMediaToCdn(params: {
     aeskey: aeskey.toString("hex"),
     fileSize: rawsize,
     fileSizeCiphertext: filesize,
+    fileMd5: rawfilemd5,
   };
 }
 

--- a/src/messaging/send.ts
+++ b/src/messaging/send.ts
@@ -254,6 +254,7 @@ export async function sendFileMessageWeixin(params: {
         encrypt_type: 1,
       },
       file_name: fileName,
+      md5: uploaded.fileMd5,
       len: String(uploaded.fileSize),
     },
   };


### PR DESCRIPTION
## Problem

When sending file attachments (e.g. `.pptx`, `.docx`, `.pdf`) via WeChat, the recipient sees a **0B file** that cannot be downloaded.

## Root Cause

The WeChat client requires the `md5` field in `file_item` for file integrity verification. Without it, the client fails to validate/download the file and displays 0B.

The `rawfilemd5` hash was already being computed in `uploadMediaToCdn()` but was **not exposed** in the `UploadedFileInfo` return type, and therefore not included in the outbound message payload.

## Fix

Two files changed (+4 lines):

1. **`src/cdn/upload.ts`**: Add `fileMd5: string` to `UploadedFileInfo` type and include `fileMd5: rawfilemd5` in the return value
2. **`src/messaging/send.ts`**: Add `md5: uploaded.fileMd5` to the `file_item` payload in `sendFileMessageWeixin()`

## Notes

- Image and video messages are **unaffected** — they use different message item structures
- Tested locally: file attachments now download correctly on the recipient side

Fixes #10