### PR TITLE
fix: synchronize version numbers across all files

### DIFF
--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -1,6 +1,6 @@
 {
   "id": "openclaw-weixin",
-  "version": "2.1.1",
+  "version": "2.1.2",
   "channels": ["openclaw-weixin"],
   "configSchema": {
     "type": "object",

--- a/src/compat.ts
+++ b/src/compat.ts
@@ -8,7 +8,7 @@
 
 import { logger } from "./util/logger.js";
 
-export const PLUGIN_VERSION = "2.0.0";
+export const PLUGIN_VERSION = "2.1.2";
 
 export const SUPPORTED_HOST_MIN = "2026.3.22";
 


### PR DESCRIPTION
## Summary
- Fix version inconsistency between `package.json`, `openclaw.plugin.json`, and `src/compat.ts`
- Update version to 2.1.2 in all files to match `package.json`

## Details
The project had three different version numbers:
- `package.json`: `2.1.2`
- `openclaw.plugin.json`: `2.1.1`
- `src/compat.ts`: `PLUGIN_VERSION = "2.0.0"`

This inconsistency could cause confusion and potential issues with:
1. Compatibility checks that rely on `PLUGIN_VERSION`
2. Plugin metadata that reports incorrect version
3. Debugging and maintenance (developers wondering which version is correct)

## Changes
- `openclaw.plugin.json`: 2.1.1 → 2.1.2
- `src/compat.ts`: `PLUGIN_VERSION` "2.0.0" → "2.1.2"

## Test plan
- All files now report version 2.1.2 consistently
- No functional changes to the code

🤖 Generated with [Claude Code](https://claude.com/claude-code)