### PR TITLE
fix: lazy-load weixin monitor during account startup

### DIFF
--- a/src/channel.ts
+++ b/src/channel.ts
@@ -24,7 +24,6 @@ import {
   waitForWeixinLogin,
 } from "./auth/login-qr.js";
 import type { WeixinQrStartResult, WeixinQrWaitResult } from "./auth/login-qr.js";
-import { monitorWeixinProvider } from "./monitor/monitor.js";
 import { sendWeixinMediaFile } from "./messaging/send-media.js";
 import { sendMessageWeixin } from "./messaging/send.js";
 import { downloadRemoteImageToTemp } from "./cdn/upload.js";
@@ -382,6 +381,10 @@ export const weixinPlugin: ChannelPlugin<ResolvedWeixinAccount> = {
 
       const logPath = aLog.getLogFilePath();
       ctx.log?.info?.(`[${account.accountId}] weixin logs: ${logPath}`);
+
+      // Load the monitor only when an account actually starts so plugin registration
+      // does not pull command-auth/provider runtime code into the loader path.
+      const { monitorWeixinProvider } = await import("./monitor/monitor.js");
 
       return monitorWeixinProvider({
         baseUrl: account.baseUrl,


### PR DESCRIPTION
## Summary

This change lazy-loads the Weixin monitor at account startup instead of importing it at module load time.

That keeps plugin registration and channel login setup from eagerly pulling in the monitor -> process-message -> provider runtime chain, which can re-enter plugin/provider registry resolution before QR login even starts.

## Changes

- remove the top-level `monitorWeixinProvider` import from `src/channel.ts`
- dynamically import `./monitor/monitor.js` inside `startAccount`
- keep the monitor runtime path unchanged once an account actually starts

## Why

In the current loading flow, importing the monitor during plugin registration can indirectly touch `openclaw/plugin-sdk/command-auth`, which may trigger provider/plugin registry resolution again from the host side.

That creates a recursive load path and can end in:

- high CPU during plugin load
- repeated runtime setup logs
- `Maximum call stack size exceeded`
- QR login never being reached

With this change, the heavy runtime path is only loaded when the account monitor is actually started.

## Validation

- installed the patched plugin from a local path
- restarted gateway
- ran `openclaw channels login --channel openclaw-weixin`
- confirmed login proceeds normally instead of failing during plugin load

Fixes #25
