### PR TITLE
test: fix pairing mock path and restore coverage

### DIFF
--- a/src/auth/pairing.test.ts
+++ b/src/auth/pairing.test.ts
@@ -16,7 +16,7 @@ const mockWithFileLock = vi.hoisted(() =>
   vi.fn(async (_path: string, _opts: unknown, fn: () => Promise<unknown>) => fn()),
 );
 
-vi.mock("openclaw/plugin-sdk", () => ({
+vi.mock("openclaw/plugin-sdk/infra-runtime", () => ({
   withFileLock: mockWithFileLock,
 }));
 
@@ -60,6 +60,35 @@ describe("resolveFrameworkAllowFromPath", () => {
     const result = resolveFrameworkAllowFromPath("abc@im.bot");
     // Only [\\/:*?"<>|] and ".." are replaced; @ and dots are preserved
     expect(result).toContain("openclaw-weixin-abc@im.bot-allowFrom.json");
+  });
+});
+
+describe("readFrameworkAllowFromList", () => {
+  it("returns empty array when file does not exist", async () => {
+    const { readFrameworkAllowFromList } = await loadModule();
+    expect(readFrameworkAllowFromList("missing-account")).toEqual([]);
+  });
+
+  it("returns filtered allowFrom list from valid file", async () => {
+    const { readFrameworkAllowFromList, resolveFrameworkAllowFromPath } = await loadModule();
+    const filePath = resolveFrameworkAllowFromPath("read-ok");
+    fs.mkdirSync(path.dirname(filePath), { recursive: true });
+    fs.writeFileSync(
+      filePath,
+      JSON.stringify({ version: 1, allowFrom: ["user-a", "", "  ", 123, "user-b"] }),
+      "utf-8",
+    );
+
+    expect(readFrameworkAllowFromList("read-ok")).toEqual(["user-a", "user-b"]);
+  });
+
+  it("returns empty array when file is unreadable or invalid", async () => {
+    const { readFrameworkAllowFromList, resolveFrameworkAllowFromPath } = await loadModule();
+    const filePath = resolveFrameworkAllowFromPath("read-bad");
+    fs.mkdirSync(path.dirname(filePath), { recursive: true });
+    fs.writeFileSync(filePath, "{not-json", "utf-8");
+
+    expect(readFrameworkAllowFromList("read-bad")).toEqual([]);
   });
 });
 

--- a/src/runtime.test.ts
+++ b/src/runtime.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("./util/logger.js", () => ({
+  logger: {
+    info: vi.fn(),
+    debug: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+async function loadModule() {
+  vi.resetModules();
+  return await import("./runtime.js");
+}
+
+describe("runtime", () => {
+  it("throws when runtime has not been initialized", async () => {
+    const { getWeixinRuntime } = await loadModule();
+    expect(() => getWeixinRuntime()).toThrow("Weixin runtime not initialized");
+  });
+
+  it("returns the runtime after initialization", async () => {
+    const { setWeixinRuntime, getWeixinRuntime } = await loadModule();
+    const runtime = { channel: { id: "chan-a" } } as any;
+
+    setWeixinRuntime(runtime);
+
+    expect(getWeixinRuntime()).toBe(runtime);
+  });
+
+  it("waits until runtime is initialized", async () => {
+    const { waitForWeixinRuntime, setWeixinRuntime } = await loadModule();
+    const runtime = { channel: { id: "chan-b" } } as any;
+
+    const promise = waitForWeixinRuntime(500);
+    setTimeout(() => setWeixinRuntime(runtime), 10);
+
+    await expect(promise).resolves.toBe(runtime);
+  });
+
+  it("times out when runtime is never initialized", async () => {
+    const { waitForWeixinRuntime } = await loadModule();
+    await expect(waitForWeixinRuntime(1)).rejects.toThrow("Weixin runtime initialization timeout");
+  });
+
+  it("prefers channelRuntime from params when provided", async () => {
+    const { resolveWeixinChannelRuntime, setWeixinRuntime } = await loadModule();
+    const globalRuntime = { channel: { id: "global" } } as any;
+    const directChannel = { id: "direct" } as any;
+
+    setWeixinRuntime(globalRuntime);
+
+    await expect(
+      resolveWeixinChannelRuntime({ channelRuntime: directChannel, waitTimeoutMs: 1 }),
+    ).resolves.toBe(directChannel);
+  });
+
+  it("falls back to global runtime channel when no direct channelRuntime exists", async () => {
+    const { resolveWeixinChannelRuntime, setWeixinRuntime } = await loadModule();
+    const globalRuntime = { channel: { id: "global-only" } } as any;
+
+    setWeixinRuntime(globalRuntime);
+
+    await expect(resolveWeixinChannelRuntime({})).resolves.toBe(globalRuntime.channel);
+  });
+
+  it("waits for runtime inside resolveWeixinChannelRuntime when needed", async () => {
+    const { resolveWeixinChannelRuntime, setWeixinRuntime } = await loadModule();
+    const runtime = { channel: { id: "late" } } as any;
+
+    const promise = resolveWeixinChannelRuntime({ waitTimeoutMs: 500 });
+    setTimeout(() => setWeixinRuntime(runtime), 10);
+
+    await expect(promise).resolves.toBe(runtime.channel);
+  });
+});


### PR DESCRIPTION
## Summary
- mock `withFileLock` from the current `openclaw/plugin-sdk/infra-runtime` import path
- add focused runtime tests so the repository coverage gate stays green

## Verification
- npm test
- npm run typecheck