### PR TITLE
fix: 修复 register() 重入导致 compat 和 runtime 日志重复输出

### DIFF
--- a/src/compat.ts
+++ b/src/compat.ts
@@ -51,9 +51,16 @@ export function isHostVersionSupported(hostVersion: string): boolean {
   return compareVersions(host, min) >= 0;
 }
 
+/** Tracks host versions that have already passed the compatibility check. */
+const checkedHostVersions = new Set<string>();
+
 /**
  * Fail-fast guard.  Call at the very start of `register()` to prevent the
  * plugin from loading on an incompatible host.
+ *
+ * On the first successful check the result is logged at `info` level.
+ * Subsequent re-entrant calls for the same version are logged at `debug`
+ * to avoid log spam when the host invokes `register()` multiple times.
  *
  * @throws {Error} with a human-readable message when the host is out of range.
  */
@@ -65,7 +72,12 @@ export function assertHostCompatibility(hostVersion: string | undefined): void {
     return;
   }
   if (isHostVersionSupported(hostVersion)) {
-    logger.info(`[compat] Host OpenClaw ${hostVersion} >= ${SUPPORTED_HOST_MIN}, OK.`);
+    if (checkedHostVersions.has(hostVersion)) {
+      logger.debug(`[compat] Host OpenClaw ${hostVersion} >= ${SUPPORTED_HOST_MIN}, OK (already verified).`);
+    } else {
+      checkedHostVersions.add(hostVersion);
+      logger.info(`[compat] Host OpenClaw ${hostVersion} >= ${SUPPORTED_HOST_MIN}, OK.`);
+    }
     return;
   }
   throw new Error(

--- a/src/runtime.ts
+++ b/src/runtime.ts
@@ -3,15 +3,25 @@ import type { PluginRuntime } from "openclaw/plugin-sdk/core";
 import { logger } from "./util/logger.js";
 
 let pluginRuntime: PluginRuntime | null = null;
+let runtimeInitialized = false;
 
 export type PluginChannelRuntime = PluginRuntime["channel"];
 
 /**
  * Sets the global Weixin runtime (called from plugin register).
+ *
+ * The first successful call is logged at `info` level.  Subsequent
+ * re-entrant calls (caused by the host re-invoking `register()`) are
+ * logged at `debug` to keep log output clean.
  */
 export function setWeixinRuntime(next: PluginRuntime): void {
   pluginRuntime = next;
-  logger.info(`[runtime] setWeixinRuntime called, runtime set successfully`);
+  if (runtimeInitialized) {
+    logger.debug(`[runtime] setWeixinRuntime called (re-entrant), runtime updated`);
+  } else {
+    runtimeInitialized = true;
+    logger.info(`[runtime] setWeixinRuntime called, runtime set successfully`);
+  }
 }
 
 /**


### PR DESCRIPTION
## 问题描述

Fixes #46

OpenClaw 宿主在配置热重载、模型列表刷新、控制台重连等场景下会多次调用插件的 `register()`，导致以下两条初始化日志每次都以 `info` 级别重复输出：

- `[compat] Host OpenClaw 2026.4.5 >= 2026.3.22, OK.`
- `[runtime] setWeixinRuntime called, runtime set successfully`

这会产生大量日志噪音，干扰排查真正的异常信息。

## 修复方案

对两处日志做进程内去重，**首次输出保持 `info` 级别不变，后续重入调用降级为 `debug`**：

### `src/compat.ts`
- 新增模块级 `Set<string>` 记录已检查过的宿主版本
- 同一版本首次检查通过：`info`（行为不变）
- 后续重复检查：降级为 `debug`

### `src/runtime.ts`
- 新增 `boolean` 标记是否已完成首次初始化
- 首次 `setWeixinRuntime()` 调用：`info`（行为不变）
- 后续重入调用：降级为 `debug`

## 测试验证

- ✅ 现有全部 14 个 compat 测试通过，无需修改
- ✅ 改动仅影响日志级别，对运行时功能逻辑零影响
- ⚠️ 仓库中已有 5 个预先失败的测试（`state-dir`、`sync-buf`），与本次修改无关（Windows 路径分隔符和超时问题）
