### PR TITLE
fix: preserve quote context (ref_msg) for voice messages

### DIFF
--- a/src/messaging/inbound.ts
+++ b/src/messaging/inbound.ts
@@ -169,28 +169,31 @@ export function isMediaItem(item: MessageItem): boolean {
   );
 }
 
+/** Prepend quoted context from ref_msg to the message text, if present. */
+function applyRefMsg(text: string, ref: MessageItem["ref_msg"]): string {
+  if (!ref) return text;
+  // Quoted media is passed as MediaPath; only include the current text as body.
+  if (ref.message_item && isMediaItem(ref.message_item)) return text;
+  // Build quoted context from both title and message_item content.
+  const parts: string[] = [];
+  if (ref.title) parts.push(ref.title);
+  if (ref.message_item) {
+    const refBody = bodyFromItemList([ref.message_item]);
+    if (refBody) parts.push(refBody);
+  }
+  if (!parts.length) return text;
+  return `[引用: ${parts.join(" | ")}]\n${text}`;
+}
+
 function bodyFromItemList(itemList?: MessageItem[]): string {
   if (!itemList?.length) return "";
   for (const item of itemList) {
     if (item.type === MessageItemType.TEXT && item.text_item?.text != null) {
-      const text = String(item.text_item.text);
-      const ref = item.ref_msg;
-      if (!ref) return text;
-      // Quoted media is passed as MediaPath; only include the current text as body.
-      if (ref.message_item && isMediaItem(ref.message_item)) return text;
-      // Build quoted context from both title and message_item content.
-      const parts: string[] = [];
-      if (ref.title) parts.push(ref.title);
-      if (ref.message_item) {
-        const refBody = bodyFromItemList([ref.message_item]);
-        if (refBody) parts.push(refBody);
-      }
-      if (!parts.length) return text;
-      return `[引用: ${parts.join(" | ")}]\n${text}`;
+      return applyRefMsg(String(item.text_item.text), item.ref_msg);
     }
     // 语音转文字：如果语音消息有 text 字段，直接使用文字内容
     if (item.type === MessageItemType.VOICE && item.voice_item?.text) {
-      return item.voice_item.text;
+      return applyRefMsg(item.voice_item.text, item.ref_msg);
     }
   }
   return "";


### PR DESCRIPTION
## Summary

- Extract shared `ref_msg` handling from the TEXT branch of `bodyFromItemList` into a reusable `applyRefMsg` helper
- Apply the same helper to the VOICE branch so voice messages with STT text preserve quoted context

Previously, when a user sent a voice message quoting a previous message, the agent only received the STT transcription with no indication of the quoted message. Now the output matches the TEXT behavior: `[引用: <quoted content>]\n<voice text>`.

Closes #48

## Changes

**`src/messaging/inbound.ts`**

Before:
```typescript
// TEXT: handles ref_msg ✅
if (item.type === TEXT && item.text_item?.text != null) {
  const text = String(item.text_item.text);
  const ref = item.ref_msg;
  // ... ref_msg logic ...
}
// VOICE: ignores ref_msg ❌
if (item.type === VOICE && item.voice_item?.text) {
  return item.voice_item.text;
}
```

After:
```typescript
function applyRefMsg(text: string, ref: MessageItem["ref_msg"]): string {
  // shared ref_msg logic
}

// TEXT: ✅
if (item.type === TEXT && ...) {
  return applyRefMsg(String(item.text_item.text), item.ref_msg);
}
// VOICE: ✅
if (item.type === VOICE && ...) {
  return applyRefMsg(item.voice_item.text, item.ref_msg);
}
```

## Test plan

- [ ] Send a text message, then quote it with a voice message — agent should see `[引用: ...]` prefix
- [ ] Send a voice message without quoting — agent should see only the STT text (no regression)
- [ ] Quote a media message (image/video) with a voice message — agent should see only the STT text (media quotes are intentionally excluded)