### PR TITLE
feat(messaging): support chunkMode for outbound text messages

### DIFF
--- a/src/messaging/process-message.ts
+++ b/src/messaging/process-message.ts
@@ -31,8 +31,13 @@ import { sendWeixinMediaFile } from "./send-media.js";
 import { StreamingMarkdownFilter } from "./markdown-filter.js";
 import { sendMessageWeixin } from "./send.js";
 import { handleSlashCommand } from "./slash-commands.js";
+import { chunkMarkdownTextWithMode, type ChunkMode } from "openclaw/plugin-sdk/reply-runtime";
 
 const MEDIA_OUTBOUND_TEMP_DIR = path.join(resolvePreferredOpenClawTmpDir(), "weixin/media/outbound-temp");
+
+// Matches DEFAULT_CHUNK_LIMIT in openclaw core (src/auto-reply/chunk.ts).
+// Can be replaced with a SDK-exported constant if one is added in the future.
+const DEFAULT_TEXT_CHUNK_LIMIT = 4000;
 
 /** Dependencies for processOneMessage, injected by the monitor loop. */
 export type ProcessMessageDeps = {
@@ -369,13 +374,20 @@ export async function processOneMessage(
             });
             logger.info(`outbound: media sent OK to=${ctx.To}`);
           } else {
-            logger.debug(`outbound: sending text message to=${ctx.To}`);
-            await sendMessageWeixin({ to: ctx.To, text, opts: {
-              baseUrl: deps.baseUrl,
-              token: deps.token,
-              contextToken,
-            }});
-            logger.info(`outbound: text sent OK to=${ctx.To}`);
+            const channelConfig = (deps.config.channels as Record<string, unknown> | undefined)?.["openclaw-weixin"] as { chunkMode?: ChunkMode; textChunkLimit?: number } | undefined;
+            const chunkMode: ChunkMode = channelConfig?.chunkMode ?? "length";
+            const textChunkLimit = channelConfig?.textChunkLimit ?? DEFAULT_TEXT_CHUNK_LIMIT;
+            const chunks = chunkMarkdownTextWithMode(text, textChunkLimit, chunkMode);
+            logger.debug(`outbound: sending text message to=${ctx.To} chunks=${chunks.length} chunkMode=${chunkMode}`);
+            for (const chunk of chunks) {
+              if (!chunk.trim()) continue;
+              await sendMessageWeixin({ to: ctx.To, text: chunk, opts: {
+                baseUrl: deps.baseUrl,
+                token: deps.token,
+                contextToken,
+              }});
+            }
+            logger.info(`outbound: text sent OK to=${ctx.To} chunks=${chunks.length}`);
           }
         } catch (err) {
           logger.error(


### PR DESCRIPTION
## Summary

This change adds `chunkMode` support to outbound text messages in the
`deliver` callback, so long AI replies can be split into multiple WeChat
messages instead of always arriving as one.

## Changes

- import `chunkMarkdownTextWithMode` and `ChunkMode` from `openclaw/plugin-sdk/reply-runtime`
- add `DEFAULT_TEXT_CHUNK_LIMIT = 4000` constant (mirrors core default)
- replace the single `sendMessageWeixin` call in the `deliver` callback with
  a chunking loop driven by `chunkMode` and `textChunkLimit` from channel config

## Why

The existing chunking logic lived in `channel.ts` → `sendText`, but `sendText`
is never called on the normal message path. The `deliver` callback in
`processOneMessage` called `sendMessageWeixin` directly, so `chunkMode` config
had no effect at runtime.

With this change, chunking is applied where messages are actually sent:

- `"length"` (default): sends as one message unless the reply exceeds
  `textChunkLimit` (4000 chars), preserving existing behavior
- `"newline"`: splits at paragraph boundaries (`\n\n`), delivering each
  paragraph as a separate WeChat message

Config keys:
channels.openclaw-weixin.chunkMode: "length" | "newline"
channels.openclaw-weixin.textChunkLimit: <number>

## Validation
- installed the plugin from local path
- set `channels.openclaw-weixin.chunkMode = "newline"` in config
- restarted gateway
- sent a multi-paragraph AI reply via WeChat
- confirmed each paragraph arrived as a separate message
- removed `chunkMode` from config and confirmed single-message behavior
  (default `"length"` mode) still works correctly