### PR TITLE
fix(pkg): ship compiled dist/ instead of TypeScript sources

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,11 +5,10 @@
   "license": "MIT",
   "author": "Tencent",
   "type": "module",
+  "main": "./dist/index.js",
   "files": [
-    "src/",
-    "!src/**/*.test.ts",
-    "!src/**/node_modules/",
-    "index.ts",
+    "dist/",
+    "!dist/**/*.map",
     "openclaw.plugin.json",
     "README.md",
     "README.zh_CN.md",
@@ -38,7 +37,7 @@
   },
   "openclaw": {
     "extensions": [
-      "./index.ts"
+      "./dist/index.js"
     ],
     "channel": {
       "id": "openclaw-weixin",


### PR DESCRIPTION
## Summary

Publish the compiled `dist/` output and point `openclaw.extensions` at `./dist/index.js`, so the OpenClaw host no longer has to transpile ~34 TypeScript files via jiti on every startup.

Fixes #71 (see that issue for the full diagnosis and CPU profile).

## Why

The repo already has a working `tsconfig.json` (emits to `dist/`) and `prepublishOnly` already runs `tsc`. But `dist/` is not listed in `package.json#files` and `openclaw.extensions` still points at `./index.ts`, so consumers receive only TS sources. That forces the host to invoke jiti on every boot — locally measured at **~5.2s of main-thread CPU out of 7.3s total** for `openclaw plugins list`. This likely contributes to the Docker startup hang in #40 (healthcheck never passes because the CPU-bound transpile happens before the gateway reports healthy).

## Change

Two fields in `package.json`:

- `files`: ship `dist/` (exclude `.map` files), drop `src/` and `index.ts`.
- `openclaw.extensions`: `./dist/index.js` instead of `./index.ts`.
- Adds `main: ./dist/index.js` for tools that honor it.

No build script or CI change needed — `prepublishOnly` already produces `dist/`.

## Measured effect

Local install, OpenClaw 2026.4.14, plugin built with this PR's layout and reinstalled:

| command | before | after |
|---|---|---|
| `openclaw plugins list` | 7.4s | **3.0s** |
| `openclaw` (bare) | 7.2s | **2.8s** |

jiti no longer appears in the top frames of the CPU profile.

Tarball: ~197kB → ~188kB unpacked, and no longer ships source.

## Test plan

- [ ] `npm install && npm run build` produces `dist/index.js` and `dist/src/**/*.js`.
- [ ] `npm pack --dry-run` shows `dist/` and no `.ts` files.
- [ ] Install the resulting tarball via `openclaw plugins install <tarball>` and verify `openclaw plugins list` reports entry path ending in `dist/index.js` and status `loaded`.
- [ ] Smoke-test the Weixin channel flow (QR login / send message) against a real bot to confirm no runtime regression from shipping compiled output.