### PR TITLE
feat: add agent binding support for WeChat accounts

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,41 @@ By default, DMs can share one session bucket. For **multiple logged-in WeChat ac
 openclaw config set session.dmScope per-account-channel-peer
 ```
 
+## Agent Binding
+
+You can bind a WeChat account to a specific Agent, so messages are routed to the designated Agent:
+
+### Binding Command
+
+After successful login, the account ID will be displayed. Use the following command to bind:
+
+```bash
+openclaw agents bind --agent <agentId> --bind openclaw-weixin:<accountId>
+```
+
+### Example
+
+```bash
+# Login to WeChat (accountId will be shown after success)
+openclaw channels login --channel openclaw-weixin
+
+# Bind to a specific agent
+openclaw agents bind --agent my-agent --bind openclaw-weixin:68af40bbb612-im-bot
+
+# Restart gateway to apply changes
+openclaw gateway restart
+```
+
+### View Current Bindings
+
+```bash
+openclaw config get bindings
+```
+
+### Unbind
+
+To remove a binding, manually edit `~/.openclaw/openclaw.json` to remove the corresponding bindings entry, or use `openclaw agents unbind`.
+
 ## Backend API Protocol
 
 This plugin communicates with the backend gateway via HTTP JSON API. Developers integrating with their own backend need to implement the following interfaces.

--- a/README.zh_CN.md
+++ b/README.zh_CN.md
@@ -71,6 +71,41 @@ openclaw channels login --channel openclaw-weixin
 openclaw config set session.dmScope per-account-channel-peer
 ```
 
+## Agent 绑定
+
+可以为微信账号绑定特定的 Agent，实现微信消息路由到指定的 Agent：
+
+### 绑定命令
+
+登录成功后会显示账号 ID，然后使用以下命令绑定：
+
+```bash
+openclaw agents bind --agent <agentId> --bind openclaw-weixin:<accountId>
+```
+
+### 示例
+
+```bash
+# 登录微信（登录成功后会显示 accountId）
+openclaw channels login --channel openclaw-weixin
+
+# 绑定到指定 agent
+openclaw agents bind --agent my-agent --bind openclaw-weixin:68af40bbb612-im-bot
+
+# 重启 gateway 使配置生效
+openclaw gateway restart
+```
+
+### 查看当前绑定
+
+```bash
+openclaw config get bindings
+```
+
+### 解绑
+
+如果需要解除绑定，可以手动编辑 `~/.openclaw/openclaw.json`，移除对应的 bindings 条目，或使用 `openclaw agents unbind` 命令。
+
 ## 后端 API 协议
 
 本插件通过 HTTP JSON API 与后端网关通信。二次开发者若需对接自有后端，需实现以下接口。

--- a/src/auth/accounts.ts
+++ b/src/auth/accounts.ts
@@ -330,6 +330,8 @@ export type ResolvedWeixinAccount = {
   /** true when a token has been obtained via QR login. */
   configured: boolean;
   name?: string;
+  /** Weixin user ID from QR login (e.g. "xxxx@im.wechat"). */
+  userId?: string;
 };
 
 type WeixinAccountConfig = {
@@ -376,5 +378,6 @@ export function resolveWeixinAccount(
     enabled: accountCfg.enabled !== false,
     configured: Boolean(token),
     name: accountCfg.name?.trim() || undefined,
+    userId: accountData?.userId,
   };
 }

--- a/src/channel.ts
+++ b/src/channel.ts
@@ -142,6 +142,7 @@ export const weixinPlugin: ChannelPlugin<ResolvedWeixinAccount> = {
     docsLabel: "openclaw-weixin",
     blurb: "getUpdates long-poll upstream, sendMessage downstream; token auth.",
     order: 75,
+    forceAccountBinding: true,
   },
   configSchema: {
     schema: {
@@ -183,7 +184,7 @@ export const weixinPlugin: ChannelPlugin<ResolvedWeixinAccount> = {
     isConfigured: (account) => account.configured,
     describeAccount: (account) => ({
       accountId: account.accountId,
-      name: account.name,
+      name: account.name ?? account.userId ?? undefined,
       enabled: account.enabled,
       configured: account.configured,
     }),
@@ -451,7 +452,9 @@ export const weixinPlugin: ChannelPlugin<ResolvedWeixinAccount> = {
 
       return {
         connected: result.connected,
-        message: result.message,
+        message: result.connected
+          ? `✅ 与微信连接成功！账号ID: ${result.accountId}，可使用 openclaw agents bind --agent <agentId> --bind openclaw-weixin:${result.accountId} 绑定到 Agent`
+          : result.message,
         accountId: result.accountId,
       } as { connected: boolean; message: string };
     },


### PR DESCRIPTION
## Summary

- Add `forceAccountBinding: true` to plugin meta so account info is always shown in `openclaw channels list`
- Include `userId` field in `ResolvedWeixinAccount` type
- Update `describeAccount` to show `userId` as fallback name
- Show binding command hint after successful QR login
- Document agent binding in English and Chinese README

## Changes

### src/auth/accounts.ts
- Add `userId` field to `ResolvedWeixinAccount` type for storing WeChat user ID from QR login
- Return `userId: accountData?.userId` from `resolveWeixinAccount()`

### src/channel.ts
- Add `forceAccountBinding: true` to plugin meta
- Update `describeAccount` to show `userId` as fallback name when `name` is not set
- Show binding command hint in login success message

## Test plan

- [x] Login to WeChat via `openclaw channels login --channel openclaw-weixin`
- [x] Verify `openclaw channels list` shows WeChat account with accountId
- [x] Verify login success message shows binding command hint with accountId
- [x] Bind WeChat account to agent: `openclaw agents bind --agent <agent> --bind openclaw-weixin:<accountId>`
- [x] Verify `openclaw config get bindings` shows correct binding
- [x] Verify WeChat messages are routed to the bound agent

## Example

```bash
# Login and bind
openclaw channels login --channel openclaw-weixin

# Bind to specific agent
openclaw agents bind --agent my-agent --bind openclaw-weixin:68af40bbb612-im-bot

# Restart gateway
openclaw gateway restart
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)