### PR TITLE
fix(monitor): getUpdates 请求遵循外部 abortSignal

### DIFF
--- a/src/api/api.ts
+++ b/src/api/api.ts
@@ -166,6 +166,11 @@ export async function apiGetFetch(params: {
 /**
  * Common fetch wrapper: POST JSON to a Weixin API endpoint with timeout + abort.
  * Returns the raw response text on success; throws on HTTP error or timeout.
+ *
+ * If `signal` is provided, the request aborts when either the internal timeout
+ * fires OR the caller's signal aborts. This allows long-poll callers (e.g. the
+ * gateway's stopChannel path) to cancel an in-flight getUpdates immediately
+ * instead of waiting up to 35s for the internal timer.
  */
 async function apiPostFetch(params: {
   baseUrl: string;
@@ -174,20 +179,29 @@ async function apiPostFetch(params: {
   token?: string;
   timeoutMs: number;
   label: string;
+  signal?: AbortSignal;
 }): Promise<string> {
   const base = ensureTrailingSlash(params.baseUrl);
   const url = new URL(params.endpoint, base);
   const hdrs = buildHeaders({ token: params.token, body: params.body });
   logger.debug(`POST ${redactUrl(url.toString())} body=${redactBody(params.body)}`);
 
+  // Fail fast if the caller's signal is already aborted.
+  if (params.signal?.aborted) {
+    throw Object.assign(new Error("aborted"), { name: "AbortError" });
+  }
+
   const controller = new AbortController();
   const t = setTimeout(() => controller.abort(), params.timeoutMs);
+  const fetchSignal = params.signal
+    ? AbortSignal.any([controller.signal, params.signal])
+    : controller.signal;
   try {
     const res = await fetch(url.toString(), {
       method: "POST",
       headers: hdrs,
       body: params.body,
-      signal: controller.signal,
+      signal: fetchSignal,
     });
     clearTimeout(t);
     const rawText = await res.text();
@@ -213,6 +227,12 @@ export async function getUpdates(
     baseUrl: string;
     token?: string;
     timeoutMs?: number;
+    /**
+     * Outer abort signal from the caller (e.g. monitor loop's stop signal).
+     * When aborted, the in-flight fetch is cancelled immediately so callers
+     * awaiting loop shutdown don't block up to `timeoutMs`.
+     */
+    signal?: AbortSignal;
   },
 ): Promise<GetUpdatesResp> {
   const timeout = params.timeoutMs ?? DEFAULT_LONG_POLL_TIMEOUT_MS;
@@ -227,10 +247,15 @@ export async function getUpdates(
       token: params.token,
       timeoutMs: timeout,
       label: "getUpdates",
+      signal: params.signal,
     });
     const resp: GetUpdatesResp = JSON.parse(rawText);
     return resp;
   } catch (err) {
+    // Caller-signal abort: propagate so the monitor loop exits promptly.
+    if (params.signal?.aborted) {
+      throw err;
+    }
     // Long-poll timeout is normal; return empty response so caller can retry
     if (err instanceof Error && err.name === "AbortError") {
       logger.debug(`getUpdates: client-side timeout after ${timeout}ms, returning empty response`);

--- a/src/monitor/monitor.ts
+++ b/src/monitor/monitor.ts
@@ -95,6 +95,7 @@ export async function monitorWeixinProvider(opts: MonitorWeixinOpts): Promise<vo
         token,
         get_updates_buf: getUpdatesBuf,
         timeoutMs: nextTimeoutMs,
+        signal: abortSignal,
       });
       aLog.debug(
         `getUpdates response: ret=${resp.ret}, msgs=${resp.msgs?.length ?? 0}, get_updates_buf_length=${resp.get_updates_buf?.length ?? 0}`,


### PR DESCRIPTION
Fixes #79。

## 改动内容

把 `monitorWeixinProvider` options 里的 `abortSignal` 透传到 `getUpdates`,再到 `apiPostFetch` 底层的 `fetch(...)` 调用,用 `AbortSignal.any([controller.signal, params.signal])` 与现有内部 timeout 信号组合。

## 动机

没有这个修复,在 `abortSignal.abort()` 之后 `await` monitor 任务的宿主会被阻塞最多 `DEFAULT_LONG_POLL_TIMEOUT_MS`(35 秒)。在 OpenClaw 里表现为:每次配置热更新、channel 重启、gateway 关机都会有数秒到数十秒的延迟。

详细分析见 #79。

## 变更细节

- `src/api/api.ts`: `apiPostFetch` 和 `getUpdates` 新增可选参数 `signal?: AbortSignal`。若传入,用 `AbortSignal.any` 与内部 timeout controller 组合。入口处对已 abort 的信号 fail-fast 抛 AbortError。
- `src/monitor/monitor.ts`: 把外部 `abortSignal` 传入 `getUpdates` 调用。

向后兼容 —— `signal` 为可选,现有调用方不受影响。

## 测试情况

在下游宿主网关回归测试:`stopChannel` 从最长 35 秒降到 <200ms(基本就是 network RTT),正常消息收发路径无 regression。

需要 Node 20+ 支持 `AbortSignal.any`。

## Checklist

- [x] 向后兼容(signal 为可选参数)
- [x] 单元测试通过(下游宿主侧)
- [x] 不修改 `DEFAULT_LONG_POLL_TIMEOUT_MS` 或其它不相关的 timer 结构
- [x] 保持 diff 最小,只改两个文件相关的几行
