### PR TITLE
fix: populate SenderId on inbound MsgContext for multi-user routing

### DIFF
--- a/src/messaging/inbound.test.ts
+++ b/src/messaging/inbound.test.ts
@@ -75,11 +75,21 @@ describe("weixinMessageToMsgContext", () => {
     expect(ctx.Timestamp).toBe(1700000000000);
   });
 
+  it("populates SenderId from from_user_id so OpenClaw core can route per-sender peer state", () => {
+    // Without SenderId, downstream memory plugins (honcho, etc.) collapse all senders
+    // into a single peer because `buildInboundUserContextPrefix` reads `ctx.SenderId`
+    // when emitting the inbound `Conversation info` metadata block. Multi-user setups
+    // depend on this field being populated.
+    const ctx = weixinMessageToMsgContext(baseMsg, "account1");
+    expect(ctx.SenderId).toBe("user123");
+  });
+
   it("handles missing from_user_id", () => {
     const msg: WeixinMessage = { item_list: [] };
     const ctx = weixinMessageToMsgContext(msg, "acc");
     expect(ctx.From).toBe("");
     expect(ctx.To).toBe("");
+    expect(ctx.SenderId).toBe("");
   });
 
   it("handles empty item_list", () => {

--- a/src/messaging/inbound.ts
+++ b/src/messaging/inbound.ts
@@ -147,6 +147,13 @@ export type WeixinMsgContext = {
   Timestamp?: number;
   Provider: "openclaw-weixin";
   ChatType: "direct";
+  /**
+   * The sender's wxid. Read by OpenClaw core's `buildInboundUserContextPrefix` to populate
+   * the `sender_id` field of the inbound `Conversation info` metadata block, which downstream
+   * memory plugins (e.g. honcho) use to route per-sender peer state. Without this, multi-user
+   * scenarios collapse all senders into a single peer.
+   */
+  SenderId?: string;
   /** Set by monitor after resolveAgentRoute so dispatchReplyFromConfig uses the correct session. */
   SessionKey?: string;
   context_token?: string;
@@ -231,6 +238,7 @@ export function weixinMessageToMsgContext(
     OriginatingChannel: "openclaw-weixin",
     OriginatingTo: from_user_id,
     MessageSid: generateMessageSid(),
+    SenderId: from_user_id,
     Timestamp: msg.create_time_ms,
     Provider: "openclaw-weixin",
     ChatType: "direct",


### PR DESCRIPTION
## Summary

Set `SenderId` on the `WeixinMsgContext` returned by `weixinMessageToMsgContext` so OpenClaw core can route per-sender peer state correctly when this plugin is used alongside multi-user-aware memory plugins (e.g. `openclaw-honcho`).

## Why

OpenClaw core's `buildInboundUserContextPrefix` reads `ctx.SenderId` to populate the `sender_id` field of the inbound `Conversation info (untrusted metadata)` block prepended to user messages. Memory plugins parse that block to attribute messages to a specific sender's peer.

Currently `weixinMessageToMsgContext` only sets `From: from_user_id` and leaves `SenderId` undefined. The resulting metadata block omits `sender_id`, so downstream plugins (e.g. honcho's `extractSenderId`) cannot identify the sender and collapse all senders into a single peer. Multi-user isolation breaks for any deployment that exposes this plugin to more than one wxid.

For comparison, the equivalent inbound builders in `@wecom/wecom-openclaw-plugin` (`monitor.js` line setting `SenderId: body.from.userid`) and `@larksuite/openclaw-lark` (`dispatch-builders.js` line setting `SenderId: opts.senderId`) already populate this field. This change brings weixin in line.

## Changes

- Add optional `SenderId?: string` to the `WeixinMsgContext` type with a doc comment explaining the contract with OpenClaw core. Optional rather than required to preserve backward compatibility for any external code that constructs this type directly.
- Set `SenderId: from_user_id` alongside `From` in `weixinMessageToMsgContext`.
- Add two test cases:
  - `SenderId` is populated from `from_user_id` for a normal message.
  - `SenderId` falls back to empty string when `from_user_id` is missing (matches the existing `From` / `To` behavior).

## Test plan

- [x] `npm run typecheck` passes.
- [x] `npm test` — 337 of 338 tests pass; the single pre-existing failure in `src/auth/pairing.test.ts > registerUserInFrameworkStore > uses withFileLock for concurrency safety` reproduces on a clean checkout of `upstream/main` and is unrelated to this change.
- [x] `npx vitest run src/messaging/inbound.test.ts` — all 26 inbound tests pass, including the two new SenderId cases.

## Diff

```
 src/messaging/inbound.test.ts | 10 ++++++++++
 src/messaging/inbound.ts      |  8 ++++++++
 2 files changed, 18 insertions(+)
```