### PR TITLE
fix: fetch failure from Content-Length header; startup runtime initialization timeout

### DIFF
--- a/src/api/api.ts
+++ b/src/api/api.ts
@@ -107,7 +107,6 @@ function buildHeaders(opts: { token?: string; body: string }): Record<string, st
   const headers: Record<string, string> = {
     "Content-Type": "application/json",
     AuthorizationType: "ilink_bot_token",
-    "Content-Length": String(Buffer.byteLength(opts.body, "utf-8")),
     "X-WECHAT-UIN": randomWechatUin(),
     ...buildCommonHeaders(),
   };

--- a/src/channel.ts
+++ b/src/channel.ts
@@ -396,6 +396,7 @@ export const weixinPlugin: ChannelPlugin<ResolvedWeixinAccount> = {
         accountId: account.accountId,
         config: ctx.cfg,
         runtime: ctx.runtime,
+        channelRuntime: ctx.channelRuntime,
         abortSignal: ctx.abortSignal,
         setStatus: ctx.setStatus,
       });

--- a/src/monitor/monitor.ts
+++ b/src/monitor/monitor.ts
@@ -25,6 +25,8 @@ export type MonitorWeixinOpts = {
   allowFrom?: string[];
   config: import("openclaw/plugin-sdk/core").OpenClawConfig;
   runtime?: { log?: (msg: string) => void; error?: (msg: string) => void };
+  /** Gateway-injected channel runtime — preferred over waitForWeixinRuntime() global. */
+  channelRuntime?: import("../runtime.js").PluginChannelRuntime;
   abortSignal?: AbortSignal;
   longPollTimeoutMs?: number;
   /** Gateway status callback — called on each successful poll and inbound message. */
@@ -52,13 +54,18 @@ export async function monitorWeixinProvider(opts: MonitorWeixinOpts): Promise<vo
 
   aLog.info(`waiting for Weixin runtime...`);
   let channelRuntime: PluginRuntime["channel"];
-  try {
-    const pluginRuntime = await waitForWeixinRuntime();
-    channelRuntime = pluginRuntime.channel;
-    aLog.info(`Weixin runtime acquired, channelRuntime type: ${typeof channelRuntime}`);
-  } catch (err) {
-    aLog.error(`waitForWeixinRuntime() failed: ${String(err)}`);
-    throw err;
+  if (opts.channelRuntime) {
+    channelRuntime = opts.channelRuntime;
+    aLog.info(`Weixin runtime from gateway context, channelRuntime type: ${typeof channelRuntime}`);
+  } else {
+    try {
+      const pluginRuntime = await waitForWeixinRuntime();
+      channelRuntime = pluginRuntime.channel;
+      aLog.info(`Weixin runtime acquired via waitForWeixinRuntime(), channelRuntime type: ${typeof channelRuntime}`);
+    } catch (err) {
+      aLog.error(`waitForWeixinRuntime() failed: ${String(err)}`);
+      throw err;
+    }
   }
 
   log(`weixin monitor started (${baseUrl}, account=${accountId})`);


### PR DESCRIPTION
## Problems Fixed

### 1. `Content-Length` header causes Node.js fetch failure

In `src/api/api.ts` `buildHeaders()`, manually setting `Content-Length` causes `TypeError: fetch failed` on Node.js 22 Undici when posting to ilinkai.weixin.qq.com.

**Fix:** Remove the `Content-Length` header — Node.js `fetch()` auto-computes it correctly.

### 2. Weixin runtime never initialized during Gateway startup

**Root cause chain:**

1. `register(api)` skips `setWeixinRuntime(api.runtime)` because `api.runtime` is `undefined` during startup
2. `startAccount(ctx)` receives `ctx.channelRuntime` from Gateway but doesn't pass it to the monitor
3. `monitorWeixinProvider()` calls `waitForWeixinRuntime()` which times out after 10s waiting for the global runtime that was never set → `Weixin runtime initialization timeout`

**Fix:**
- `src/channel.ts` `startAccount`: Pass `channelRuntime: ctx.channelRuntime` to monitor
- `src/monitor/monitor.ts`: Prefer direct `opts.channelRuntime` from Gateway, fallback to old `waitForWeixinRuntime()` for non-startup flows