### PR TITLE
[codex] Fix Weixin runtime startup and request headers

### DIFF
--- a/src/api/api.test.ts
+++ b/src/api/api.test.ts
@@ -86,6 +86,16 @@ describe("getUpdates", () => {
     const [url] = mockFetch.mock.calls[0];
     expect(url).toContain("https://api.example.com/ilink/bot/getupdates");
   });
+
+  it("does not set Content-Length manually", async () => {
+    mockFetch.mockResolvedValueOnce(mockResponse({ ret: 0 }));
+    await getUpdates({
+      baseUrl: "https://api.example.com",
+      get_updates_buf: "old-buf",
+    });
+    const [, opts] = mockFetch.mock.calls[0];
+    expect(opts.headers).not.toHaveProperty("Content-Length");
+  });
 });
 
 describe("getUploadUrl", () => {

--- a/src/api/api.ts
+++ b/src/api/api.ts
@@ -107,7 +107,6 @@ function buildHeaders(opts: { token?: string; body: string }): Record<string, st
   const headers: Record<string, string> = {
     "Content-Type": "application/json",
     AuthorizationType: "ilink_bot_token",
-    "Content-Length": String(Buffer.byteLength(opts.body, "utf-8")),
     "X-WECHAT-UIN": randomWechatUin(),
     ...buildCommonHeaders(),
   };

--- a/src/auth/pairing.test.ts
+++ b/src/auth/pairing.test.ts
@@ -16,7 +16,7 @@ const mockWithFileLock = vi.hoisted(() =>
   vi.fn(async (_path: string, _opts: unknown, fn: () => Promise<unknown>) => fn()),
 );
 
-vi.mock("openclaw/plugin-sdk", () => ({
+vi.mock("openclaw/plugin-sdk/infra-runtime", () => ({
   withFileLock: mockWithFileLock,
 }));
 

--- a/src/channel.ts
+++ b/src/channel.ts
@@ -1,6 +1,6 @@
 import path from "node:path";
 
-import type { ChannelPlugin, OpenClawConfig } from "openclaw/plugin-sdk/core";
+import type { ChannelPlugin, OpenClawConfig, PluginRuntime } from "openclaw/plugin-sdk/core";
 import { normalizeAccountId } from "openclaw/plugin-sdk/account-id";
 import { resolvePreferredOpenClawTmpDir } from "openclaw/plugin-sdk/infra-runtime";
 
@@ -398,6 +398,7 @@ export const weixinPlugin: ChannelPlugin<ResolvedWeixinAccount> = {
         runtime: ctx.runtime,
         abortSignal: ctx.abortSignal,
         setStatus: ctx.setStatus,
+        channelRuntime: ctx.channelRuntime ?? (ctx.runtime as unknown as PluginRuntime["channel"]),
       });
     },
     loginWithQrStart: async ({ accountId, force, timeoutMs, verbose }) => {

--- a/src/messaging/process-message.ts
+++ b/src/messaging/process-message.ts
@@ -38,7 +38,7 @@ const MEDIA_OUTBOUND_TEMP_DIR = path.join(resolvePreferredOpenClawTmpDir(), "wei
 export type ProcessMessageDeps = {
   accountId: string;
   config: import("openclaw/plugin-sdk/core").OpenClawConfig;
-  channelRuntime: PluginRuntime["channel"];
+  channelRuntime: PluginRuntime["channel"] | null;
   baseUrl: string;
   cdnBaseUrl: string;
   token?: string;
@@ -73,6 +73,7 @@ export async function processOneMessage(
     deps.errLog("processOneMessage: channelRuntime is undefined, skip");
     return;
   }
+  const channelRuntime = deps.channelRuntime;
 
   const receivedAt = Date.now();
   const debug = isDebugMode(deps.accountId);
@@ -143,7 +144,7 @@ export async function processOneMessage(
     const label = refMediaItem ? "ref" : "inbound";
     const downloaded = await downloadMediaFromItem(mediaItem, {
       cdnBaseUrl: deps.cdnBaseUrl,
-      saveMedia: deps.channelRuntime.media.saveMediaBuffer,
+      saveMedia: channelRuntime.media.saveMediaBuffer,
       log: deps.log,
       errLog: deps.errLog,
       label,
@@ -184,7 +185,7 @@ export async function processOneMessage(
         const uid = loadWeixinAccount(deps.accountId)?.userId?.trim();
         return uid ? [uid] : [];
       },
-      runtime: deps.channelRuntime.commands,
+      runtime: channelRuntime.commands,
     });
 
   const directDmOutcome = resolveDirectDmAuthorizationOutcome({
@@ -212,7 +213,7 @@ export async function processOneMessage(
     );
   }
 
-  const route = deps.channelRuntime.routing.resolveAgentRoute({
+  const route = channelRuntime.routing.resolveAgentRoute({
     cfg: deps.config,
     channel: "openclaw-weixin",
     accountId: deps.accountId,
@@ -237,11 +238,11 @@ export async function processOneMessage(
   // the correct session (matching the dmScope from config) instead of falling back
   // to agent:main:main.
   ctx.SessionKey = route.sessionKey;
-  const storePath = deps.channelRuntime.session.resolveStorePath(deps.config.session?.store, {
+  const storePath = channelRuntime.session.resolveStorePath(deps.config.session?.store, {
     agentId: route.agentId,
   });
-  const finalized = deps.channelRuntime.reply.finalizeInboundContext(
-    ctx as Parameters<typeof deps.channelRuntime.reply.finalizeInboundContext>[0],
+  const finalized = channelRuntime.reply.finalizeInboundContext(
+    ctx as Parameters<typeof channelRuntime.reply.finalizeInboundContext>[0],
   );
 
   logger.info(
@@ -249,10 +250,10 @@ export async function processOneMessage(
   );
   logger.debug(`inbound context: ${redactBody(JSON.stringify(finalized))}`);
 
-  await deps.channelRuntime.session.recordInboundSession({
+  await channelRuntime.session.recordInboundSession({
     storePath,
     sessionKey: route.sessionKey,
-    ctx: finalized as Parameters<typeof deps.channelRuntime.session.recordInboundSession>[0]["ctx"],
+    ctx: finalized as Parameters<typeof channelRuntime.session.recordInboundSession>[0]["ctx"],
     updateLastRoute: {
       sessionKey: route.mainSessionKey,
       channel: "openclaw-weixin",
@@ -269,7 +270,7 @@ export async function processOneMessage(
   if (contextToken) {
     setContextToken(deps.accountId, full.from_user_id ?? "", contextToken);
   }
-  const humanDelay = deps.channelRuntime.reply.resolveHumanDelayConfig(deps.config, route.agentId);
+  const humanDelay = channelRuntime.reply.resolveHumanDelayConfig(deps.config, route.agentId);
 
   const hasTypingTicket = Boolean(deps.typingTicket);
   const typingCallbacks = createTypingCallbacks({
@@ -306,7 +307,7 @@ export async function processOneMessage(
   const debugDeliveries: Array<{ textLen: number; media: string; preview: string; ts: number }> = [];
 
   const { dispatcher, replyOptions, markDispatchIdle } =
-    deps.channelRuntime.reply.createReplyDispatcherWithTyping({
+    channelRuntime.reply.createReplyDispatcherWithTyping({
       humanDelay,
       typingCallbacks,
       deliver: async (payload) => {
@@ -412,10 +413,10 @@ export async function processOneMessage(
 
   logger.debug(`dispatchReplyFromConfig: starting agentId=${route.agentId ?? "(none)"}`);
   try {
-    await deps.channelRuntime.reply.withReplyDispatcher({
+    await channelRuntime.reply.withReplyDispatcher({
       dispatcher,
       run: () =>
-        deps.channelRuntime.reply.dispatchReplyFromConfig({
+        channelRuntime.reply.dispatchReplyFromConfig({
           ctx: finalized,
           cfg: deps.config,
           dispatcher,

--- a/src/monitor/monitor.test.ts
+++ b/src/monitor/monitor.test.ts
@@ -1,0 +1,79 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const runtimeMocks = vi.hoisted(() => ({
+  resolveWeixinChannelRuntime: vi.fn(),
+  waitForWeixinRuntime: vi.fn(),
+}));
+
+vi.mock("../runtime.js", () => ({
+  resolveWeixinChannelRuntime: runtimeMocks.resolveWeixinChannelRuntime,
+  waitForWeixinRuntime: runtimeMocks.waitForWeixinRuntime,
+}));
+
+vi.mock("../api/api.js", () => ({
+  getUpdates: vi.fn(),
+}));
+
+vi.mock("../api/config-cache.js", () => ({
+  WeixinConfigManager: vi.fn(),
+}));
+
+vi.mock("../api/session-guard.js", () => ({
+  SESSION_EXPIRED_ERRCODE: -1,
+  pauseSession: vi.fn(),
+  getRemainingPauseMs: vi.fn(() => 0),
+}));
+
+vi.mock("../messaging/process-message.js", () => ({
+  processOneMessage: vi.fn(),
+}));
+
+vi.mock("../storage/sync-buf.js", () => ({
+  getSyncBufFilePath: vi.fn(() => "/tmp/openclaw-weixin-test-sync-buf"),
+  loadGetUpdatesBuf: vi.fn(() => ""),
+  saveGetUpdatesBuf: vi.fn(),
+}));
+
+vi.mock("../util/logger.js", () => ({
+  logger: {
+    withAccount: vi.fn(() => ({
+      info: vi.fn(),
+      debug: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+    })),
+  },
+}));
+
+import { monitorWeixinProvider } from "./monitor.js";
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  runtimeMocks.resolveWeixinChannelRuntime.mockResolvedValue({ commands: {} });
+  runtimeMocks.waitForWeixinRuntime.mockRejectedValue(new Error("global runtime unavailable"));
+});
+
+describe("monitorWeixinProvider", () => {
+  it("uses injected channelRuntime instead of waiting for the global runtime", async () => {
+    const channelRuntime = { commands: {} };
+    const abortController = new AbortController();
+    abortController.abort();
+
+    await expect(
+      monitorWeixinProvider({
+        baseUrl: "https://api.example.com",
+        cdnBaseUrl: "https://cdn.example.com",
+        accountId: "acct",
+        config: {} as never,
+        abortSignal: abortController.signal,
+        channelRuntime: channelRuntime as never,
+      }),
+    ).resolves.toBeUndefined();
+
+    expect(runtimeMocks.resolveWeixinChannelRuntime).toHaveBeenCalledWith({
+      channelRuntime,
+      waitTimeoutMs: 30_000,
+    });
+    expect(runtimeMocks.waitForWeixinRuntime).not.toHaveBeenCalled();
+  });
+});

--- a/src/monitor/monitor.ts
+++ b/src/monitor/monitor.ts
@@ -5,7 +5,7 @@ import { getUpdates } from "../api/api.js";
 import { WeixinConfigManager } from "../api/config-cache.js";
 import { SESSION_EXPIRED_ERRCODE, pauseSession, getRemainingPauseMs } from "../api/session-guard.js";
 import { processOneMessage } from "../messaging/process-message.js";
-import { getWeixinRuntime, waitForWeixinRuntime } from "../runtime.js";
+import { resolveWeixinChannelRuntime } from "../runtime.js";
 import { getSyncBufFilePath, loadGetUpdatesBuf, saveGetUpdatesBuf } from "../storage/sync-buf.js";
 import { logger } from "../util/logger.js";
 import type { Logger } from "../util/logger.js";
@@ -29,6 +29,7 @@ export type MonitorWeixinOpts = {
   longPollTimeoutMs?: number;
   /** Gateway status callback — called on each successful poll and inbound message. */
   setStatus?: (next: ChannelAccountSnapshot) => void;
+  channelRuntime?: PluginRuntime["channel"];
 };
 
 /**
@@ -51,14 +52,16 @@ export async function monitorWeixinProvider(opts: MonitorWeixinOpts): Promise<vo
   const aLog: Logger = logger.withAccount(accountId);
 
   aLog.info(`waiting for Weixin runtime...`);
-  let channelRuntime: PluginRuntime["channel"];
+  let channelRuntime: PluginRuntime["channel"] | null;
   try {
-    const pluginRuntime = await waitForWeixinRuntime();
-    channelRuntime = pluginRuntime.channel;
+    channelRuntime = await resolveWeixinChannelRuntime({
+      channelRuntime: opts.channelRuntime,
+      waitTimeoutMs: 30_000,
+    });
     aLog.info(`Weixin runtime acquired, channelRuntime type: ${typeof channelRuntime}`);
   } catch (err) {
-    aLog.error(`waitForWeixinRuntime() failed: ${String(err)}`);
-    throw err;
+    aLog.warn(`Weixin runtime not available after 30s: ${String(err)}`);
+    channelRuntime = null;
   }
 
   log(`weixin monitor started (${baseUrl}, account=${accountId})`);

--- a/src/runtime.test.ts
+++ b/src/runtime.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+
+vi.mock("./util/logger.js", () => ({
+  logger: {
+    info: vi.fn(),
+    debug: vi.fn(),
+    warn: vi.fn(),
+  },
+}));
+
+async function loadRuntimeModule() {
+  vi.resetModules();
+  return await import("./runtime.js");
+}
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe("runtime helpers", () => {
+  it("throws when global runtime is not initialized", async () => {
+    const { getWeixinRuntime } = await loadRuntimeModule();
+    expect(() => getWeixinRuntime()).toThrow("Weixin runtime not initialized");
+  });
+
+  it("sets and returns the global runtime", async () => {
+    const { setWeixinRuntime, getWeixinRuntime } = await loadRuntimeModule();
+    const runtime = { channel: { reply: {} } };
+    setWeixinRuntime(runtime as never);
+    expect(getWeixinRuntime()).toBe(runtime);
+  });
+
+  it("resolves an injected channelRuntime without reading the global runtime", async () => {
+    const { resolveWeixinChannelRuntime } = await loadRuntimeModule();
+    const channelRuntime = { reply: {} };
+    await expect(
+      resolveWeixinChannelRuntime({ channelRuntime: channelRuntime as never }),
+    ).resolves.toBe(channelRuntime);
+  });
+
+  it("falls back to the global runtime channel", async () => {
+    const { setWeixinRuntime, resolveWeixinChannelRuntime } = await loadRuntimeModule();
+    const channel = { reply: {} };
+    setWeixinRuntime({ channel } as never);
+    await expect(resolveWeixinChannelRuntime({})).resolves.toBe(channel);
+  });
+
+  it("waits up to the default 30s timeout", async () => {
+    vi.useFakeTimers();
+    const { waitForWeixinRuntime } = await loadRuntimeModule();
+
+    const waiting = waitForWeixinRuntime();
+    const assertion = expect(waiting).rejects.toThrow(
+      "Weixin runtime initialization timeout",
+    );
+    await vi.advanceTimersByTimeAsync(30_100);
+
+    await assertion;
+  });
+});

--- a/src/runtime.ts
+++ b/src/runtime.ts
@@ -25,7 +25,7 @@ export function getWeixinRuntime(): PluginRuntime {
 }
 
 const WAIT_INTERVAL_MS = 100;
-const DEFAULT_TIMEOUT_MS = 10_000;
+const DEFAULT_TIMEOUT_MS = 30_000;
 
 /**
  * Waits for the Weixin runtime to be initialized (async polling).

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -3,6 +3,7 @@ import { defineConfig } from "vitest/config";
 export default defineConfig({
   test: {
     globals: true,
+    testTimeout: 30_000,
     coverage: {
       provider: "v8",
       include: ["src/**/*.ts"],


### PR DESCRIPTION
## Summary
- Remove the manual `Content-Length` header from JSON POST requests so fetch/undici can calculate it correctly.
- Resolve monitor channel runtime from the gateway-injected `channelRuntime`, extend runtime wait defaults to 30s, and degrade instead of crashing when unavailable.
- Pass `channelRuntime` from `startAccount` and allow message processing to skip cleanly when runtime helpers are unavailable.
- Add regression coverage for request headers, monitor runtime resolution, runtime timeout behavior, and stabilize existing Vitest coverage runs.

## Root cause
The login failure was caused by manually setting `Content-Length`, which can conflict with undici body serialization. The monitor crash loop happened because account subprocesses do not call plugin `register()`, so waiting only on the module-global runtime can time out forever.

## Validation
- `npx vitest run src/api/api.test.ts src/monitor/monitor.test.ts`
- `npm test`
- `npm run typecheck`
- `npm run build`