### PR TITLE
fix(api): drop manual Content-Length header so fetch does not fail under undici 7

### DIFF
--- a/src/api/api.test.ts
+++ b/src/api/api.test.ts
@@ -147,6 +147,25 @@ describe("getConfig", () => {
   });
 });
 
+describe("buildHeaders / fetch headers contract (regression: openclaw#78434)", () => {
+  it("does not pass a manual Content-Length header to fetch", async () => {
+    // Modern undici (Node 24, undici 7.x) rejects user-supplied
+    // Content-Length headers synchronously with InvalidArgumentError
+    // from request.processHeader, surfacing as `TypeError: fetch failed`
+    // and breaking `channels login --channel openclaw-weixin`.
+    mockFetch.mockResolvedValueOnce(mockResponse({ ret: 0 }));
+    await sendMessage({
+      baseUrl: "https://api.example.com/",
+      token: "tok",
+      body: { ilink_user_id: "u", ilink_chat_id: "c", body: { msg: "hi" } },
+    });
+    const [, opts] = mockFetch.mock.calls[0];
+    const sentHeaders = (opts.headers ?? {}) as Record<string, string>;
+    const headerKeys = Object.keys(sentHeaders).map((key) => key.toLowerCase());
+    expect(headerKeys).not.toContain("content-length");
+  });
+});
+
 describe("sendTyping", () => {
   it("succeeds on ok response", async () => {
     mockFetch.mockResolvedValueOnce(mockResponse({ ret: 0 }));

--- a/src/api/api.ts
+++ b/src/api/api.ts
@@ -104,10 +104,15 @@ function buildCommonHeaders(): Record<string, string> {
 }
 
 function buildHeaders(opts: { token?: string; body: string }): Record<string, string> {
+  // `Content-Length` is a forbidden request header in the WHATWG fetch spec
+  // (https://fetch.spec.whatwg.org/#forbidden-header-name). fetch is required
+  // to set it from the body; modern undici (Node 24, undici 7.x) rejects a
+  // user-supplied value synchronously with `InvalidArgumentError: invalid
+  // content-length header` from `processHeader`, surfacing as `TypeError:
+  // fetch failed` to callers. Older undici versions silently stripped it.
   const headers: Record<string, string> = {
     "Content-Type": "application/json",
     AuthorizationType: "ilink_bot_token",
-    "Content-Length": String(Buffer.byteLength(opts.body, "utf-8")),
     "X-WECHAT-UIN": randomWechatUin(),
     ...buildCommonHeaders(),
   };


### PR DESCRIPTION
Closes #119.

## Summary

`Content-Length` is a [forbidden request header](https://fetch.spec.whatwg.org/#forbidden-header-name) in the WHATWG fetch spec — fetch is required to set it from the body and reject user-supplied values. Modern undici (Node 24's bundled 7.x) enforces this strictly: a manual `Content-Length` header triggers a synchronous `InvalidArgumentError: invalid content-length header` from `request.processHeader`, which surfaces to callers as the unhelpful `TypeError: fetch failed` and breaks `openclaw channels login --channel openclaw-weixin` (and any POST that flows through `apiPostFetch`).

Older undici versions silently stripped the user-supplied header, which is presumably why this only started biting on a recent OpenClaw / Node combo. Reported in openclaw/openclaw#78434.

## Diff

`src/api/api.ts` `buildHeaders()`: remove the line

```ts
"Content-Length": String(Buffer.byteLength(opts.body, "utf-8")),
```

Fetch computes `Content-Length` from the body itself when one is supplied. Added a multi-line comment explaining why the line is intentionally absent so future contributors don't accidentally reintroduce it.

## Regression test

Added in `src/api/api.test.ts`:

```ts
it("does not pass a manual Content-Length header to fetch", async () => {
  // ... assert mockFetch.mock.calls[0][1].headers has no content-length
});
```

Locks in the fix and prevents reintroduction.

## Verification

Real reproduction from openclaw#78434:

```bash
openclaw plugins install '@tencent-weixin/openclaw-weixin@2.4.1'
launchctl kickstart -k gui/$(id -u)/ai.openclaw.gateway
openclaw channels login --channel openclaw-weixin
# 正在启动...
# Failed to start login: TypeError: fetch failed
```

Captured the underlying cause by instrumenting `apiPostFetch` to log `err.cause`:

```
[diag] POST https://ilinkai.weixin.qq.com/ilink/bot/get_bot_qrcode?bot_type=3 err.cause= InvalidArgumentError: invalid content-length header
    at processHeader (.../node_modules/undici/lib/core/request.js:503:13)
```

After applying this patch and re-running the same login command, the QR code renders correctly:

```
正在启动...

用手机微信扫描以下二维码，以继续连接：

▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄
█ ▄▄▄▄▄ █▄▄██████▄▀▀▄██▄ ▄▀▄█▀█ ▄▄▄▄▄ █
...
```

`pnpm typecheck` clean. `pnpm exec vitest run src/api/api.test.ts` → 14/14 passed (13 existing + 1 new regression test).

## What did NOT change

- No other endpoints touched. `apiGetFetch` already used `buildCommonHeaders` (no manual `Content-Length`). Long-poll `getUpdates` also goes through `buildHeaders` and benefits from this fix.
- No body-construction change. `Buffer.byteLength` is no longer needed for header computation but no other code referenced it.
- No bump to npm engines or undici dependency. The fix is spec-compliance, not a workaround for a specific undici version.