### PR TITLE
fix: remove manual Content-Length and pass channelRuntime to fix gateway worker isolation

### DIFF
--- a/src/api/api.ts
+++ b/src/api/api.ts
@@ -107,7 +107,6 @@ function buildHeaders(opts: { token?: string; body: string }): Record<string, st
   const headers: Record<string, string> = {
     "Content-Type": "application/json",
     AuthorizationType: "ilink_bot_token",
-    "Content-Length": String(Buffer.byteLength(opts.body, "utf-8")),
     "X-WECHAT-UIN": randomWechatUin(),
     ...buildCommonHeaders(),
   };

--- a/src/channel.ts
+++ b/src/channel.ts
@@ -396,6 +396,7 @@ export const weixinPlugin: ChannelPlugin<ResolvedWeixinAccount> = {
         accountId: account.accountId,
         config: ctx.cfg,
         runtime: ctx.runtime,
+        channelRuntime: ctx.channelRuntime,
         abortSignal: ctx.abortSignal,
         setStatus: ctx.setStatus,
       });

--- a/src/monitor/monitor.ts
+++ b/src/monitor/monitor.ts
@@ -5,7 +5,7 @@ import { getUpdates } from "../api/api.js";
 import { WeixinConfigManager } from "../api/config-cache.js";
 import { SESSION_EXPIRED_ERRCODE, pauseSession, getRemainingPauseMs } from "../api/session-guard.js";
 import { processOneMessage } from "../messaging/process-message.js";
-import { getWeixinRuntime, waitForWeixinRuntime } from "../runtime.js";
+import { getWeixinRuntime, resolveWeixinChannelRuntime, type PluginChannelRuntime } from "../runtime.js";
 import { getSyncBufFilePath, loadGetUpdatesBuf, saveGetUpdatesBuf } from "../storage/sync-buf.js";
 import { logger } from "../util/logger.js";
 import type { Logger } from "../util/logger.js";
@@ -25,6 +25,8 @@ export type MonitorWeixinOpts = {
   allowFrom?: string[];
   config: import("openclaw/plugin-sdk/core").OpenClawConfig;
   runtime?: { log?: (msg: string) => void; error?: (msg: string) => void };
+  /** Gateway-injected channel runtime — avoids worker-scope race with register(). */
+  channelRuntime?: PluginChannelRuntime;
   abortSignal?: AbortSignal;
   longPollTimeoutMs?: number;
   /** Gateway status callback — called on each successful poll and inbound message. */
@@ -53,11 +55,12 @@ export async function monitorWeixinProvider(opts: MonitorWeixinOpts): Promise<vo
   aLog.info(`waiting for Weixin runtime...`);
   let channelRuntime: PluginRuntime["channel"];
   try {
-    const pluginRuntime = await waitForWeixinRuntime();
-    channelRuntime = pluginRuntime.channel;
+    channelRuntime = await resolveWeixinChannelRuntime({
+      channelRuntime: opts.channelRuntime,
+    });
     aLog.info(`Weixin runtime acquired, channelRuntime type: ${typeof channelRuntime}`);
   } catch (err) {
-    aLog.error(`waitForWeixinRuntime() failed: ${String(err)}`);
+    aLog.error(`resolveWeixinChannelRuntime() failed: ${String(err)}`);
     throw err;
   }
 


### PR DESCRIPTION
## Summary

Two bugs prevent the plugin from working with OpenClaw Gateway's worker-based channel isolation.

### Bug 1: Manual Content-Length header causes InvalidArgumentError

**File:** `src/api/api.ts`

`buildHeaders()` manually sets `Content-Length` via `Buffer.byteLength()`. OpenClaw Gateway uses `undici`'s `fetch()` which auto-computes `Content-Length` and rejects duplicate values with `InvalidArgumentError`. This makes every API call (login QR code, getUpdates, etc.) fail with `TypeError: fetch failed`.

**Fix:** Remove the manual `Content-Length` line. Let `fetch()` compute it automatically.

### Bug 2: waitForWeixinRuntime() times out in channel worker scope

**Files:** `src/channel.ts`, `src/monitor/monitor.ts`

Gateway runs channels in isolated workers. `register()` sets a module-level `pluginRuntime` that is invisible to the channel worker (different module scope). The monitor's `waitForWeixinRuntime()` polls this global indefinitely and always times out with `Weixin runtime initialization timeout`.

The project already ships `resolveWeixinChannelRuntime()` in `runtime.ts` which handles this exact case — it checks an explicitly-passed `channelRuntime` first, then falls back to the global. But neither `channel.ts` nor `monitor.ts` use it.

**Fix:**
- `channel.ts`: pass `ctx.channelRuntime` to `monitorWeixinProvider()`
- `monitor.ts`: accept `channelRuntime` in opts, use `resolveWeixinChannelRuntime()` instead of `waitForWeixinRuntime()`

## Testing

Tested on macOS (Darwin x86_64) with OpenClaw 2026.5.6:
- ✅ QR code login works
- ✅ Runtime acquired without timeout
- ✅ Inbound WeChat messages received and processed

## Files Changed

- `src/api/api.ts`: Remove manual `Content-Length` from `buildHeaders()`
- `src/channel.ts`: Pass `channelRuntime: ctx.channelRuntime` to `monitorWeixinProvider()`
- `src/monitor/monitor.ts`: Add `channelRuntime` to `MonitorWeixinOpts`; use `resolveWeixinChannelRuntime()`
