### PR TITLE
fix(api): drop manual Content-Length header rejected by modern undici

### DIFF
--- a/src/api/api.ts
+++ b/src/api/api.ts
@@ -104,10 +104,13 @@ function buildCommonHeaders(): Record<string, string> {
 }
 
 function buildHeaders(opts: { token?: string; body: string }): Record<string, string> {
+  // Do NOT set Content-Length manually. Modern undici (used by Node 22+ and openclaw's
+  // bundled undici) treats it as a forbidden request-header on fetch() and rejects the
+  // request with `UND_ERR_INVALID_ARG: invalid content-length header` before sending.
+  // The runtime computes Content-Length from the body automatically.
   const headers: Record<string, string> = {
     "Content-Type": "application/json",
     AuthorizationType: "ilink_bot_token",
-    "Content-Length": String(Buffer.byteLength(opts.body, "utf-8")),
     "X-WECHAT-UIN": randomWechatUin(),
     ...buildCommonHeaders(),
   };


### PR DESCRIPTION
Fixes #129.

## Summary

Remove the manual `Content-Length` line from `buildHeaders` in `src/api/api.ts`. `fetch()` computes `Content-Length` from the body automatically, and modern `undici` (Node 22+ built-in, openclaw's bundled undici 6.x+) treats `content-length` as a forbidden request-header — it rejects every weixin POST synchronously with `UND_ERR_INVALID_ARG: invalid content-length header`.

## Why this currently bites

A bare `node -e "fetch(...)"` against `https://ilinkai.weixin.qq.com` works (HTTP 200) because Node's built-in undici is older / more lenient. The plugin's `fetch()` only fails when a stricter undici is in scope, which is the common case for openclaw and any Node 22+ host that pins a recent undici. The error surfaces as a generic `TypeError: fetch failed` — the underlying cause (`InvalidArgumentError: invalid content-length header at processHeader`) is only visible after pulling `error.cause`.

See #129 for full reproduction trace.

## Diff

```diff
 function buildHeaders(opts: { token?: string; body: string }): Record<string, string> {
+  // Do NOT set Content-Length manually. Modern undici (used by Node 22+ and openclaw's
+  // bundled undici) treats it as a forbidden request-header on fetch() and rejects the
+  // request with `UND_ERR_INVALID_ARG: invalid content-length header` before sending.
+  // The runtime computes Content-Length from the body automatically.
   const headers: Record<string, string> = {
     "Content-Type": "application/json",
     AuthorizationType: "ilink_bot_token",
-    "Content-Length": String(Buffer.byteLength(opts.body, "utf-8")),
     "X-WECHAT-UIN": randomWechatUin(),
     ...buildCommonHeaders(),
   };
```

## Verification

- `npm run typecheck` — clean
- Manual: applied the equivalent change to a 2.4.1 install in `~/.openclaw/npm/node_modules/@tencent-weixin/openclaw-weixin/dist/src/api/api.js`. weixin login QR fetch + notifyStart + getUpdates + sendMessage all start succeeding immediately. Inbound messages flow.

## Test plan

- [x] Typecheck
- [ ] Build + run against openclaw 2026.5.x (verified by patch on installed dist)
- [ ] Add a unit test that constructs `buildHeaders` and asserts no `Content-Length` key (optional follow-up)
