### PR TITLE
fix: add dist/ to package.json files field

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   "type": "module",
   "files": [
     "src/",
+    "dist/",
     "!src/**/*.test.ts",
     "!src/**/node_modules/",
     "index.ts",


### PR DESCRIPTION
## Problem

OpenClaw requires compiled runtime output (dist/index.js) as the plugin entry point, but the package.json `files` field was missing `dist/`. This caused plugin load warnings on install:

```
plugin openclaw-weixin: installed plugin package requires compiled runtime output for TypeScript entry index.ts: expected ./dist/index.js
```

## Fix

Add `dist/` to the `files` array in package.json so that `npm pack` includes the compiled output.

## Testing

```bash
npm run build   # compiles TypeScript to dist/
npm pack --dry-run  # verifies dist/ is included
```

Plugin now loads without warnings.