### PR TITLE
debug: log bindings summary before resolveAgentRoute (issue #135)

### DIFF
--- a/src/messaging/process-message.ts
+++ b/src/messaging/process-message.ts
@@ -212,6 +212,14 @@ export async function processOneMessage(
     );
   }
 
+  // Log bindings summary at debug level to help diagnose routing issues (issue #135).
+  // Remove these logs once routing is confirmed working.
+  const bindingSummary = (deps.config.bindings ?? []).map((b) =>
+    JSON.stringify({ channel: b.match?.channel, peer: b.match?.peer, agentId: b.agentId }),
+  );
+  logger.debug(
+    `resolveAgentRoute: channel=openclaw-weixin accountId=${deps.accountId} peer=direct:${ctx.To} bindings=[${bindingSummary.join(", ")}]`,
+  );
   const route = deps.channelRuntime.routing.resolveAgentRoute({
     cfg: deps.config,
     channel: "openclaw-weixin",
@@ -219,7 +227,7 @@ export async function processOneMessage(
     peer: { kind: "direct", id: ctx.To },
   });
   logger.debug(
-    `resolveAgentRoute: agentId=${route.agentId ?? "(none)"} sessionKey=${route.sessionKey ?? "(none)"} mainSessionKey=${route.mainSessionKey ?? "(none)"}`,
+    `resolveAgentRoute result: agentId=${route.agentId ?? "(none)"} sessionKey=${route.sessionKey ?? "(none)"} mainSessionKey=${route.mainSessionKey ?? "(none)"} matchedBy=${route.matchedBy}`,
   );
   if (!route.agentId) {
     logger.error(


### PR DESCRIPTION
## Debug logging for Issue #135

This PR adds debug logging to help diagnose why WeChat messages always route to the main agent regardless of binding rules.

### Changes
- Log the full `bindings[]` array from `deps.config` before calling `resolveAgentRoute`
- Log the resolved `matchedBy` field in the result (indicates which routing tier matched)
- Log channel, accountId, and peer parameters passed to `resolveAgentRoute`

### How to test
1. Apply this PR
2. Enable debug logging in gateway
3. Send a WeChat DM to the bot
4. Check logs for:
   - `resolveAgentRoute: channel=openclaw-weixin ... bindings=[...]` — shows effective bindings
   - `resolveAgentRoute result: ... matchedBy=...` — shows which tier matched

If `matchedBy` is `default` instead of `binding.peer`, the binding is not matching for WeChat DMs.

**Issue:** #135