### PR TITLE
Declare Weixin plugin runtime metadata

### DIFF
--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -4,6 +4,13 @@
   "channels": [
     "openclaw-weixin"
   ],
+  "channelConfigs": {
+    "openclaw-weixin": {
+      "schema": {
+        "type": "object"
+      }
+    }
+  },
   "configSchema": {
     "type": "object",
     "additionalProperties": false,

--- a/package.json
+++ b/package.json
@@ -37,6 +37,9 @@
     "vitest": "^3.1.0"
   },
   "openclaw": {
+    "runtimeExtensions": [
+      "./index.ts"
+    ],
     "extensions": [
       "./index.ts"
     ],


### PR DESCRIPTION
## Summary
- Declare the Weixin channel configuration schema in the plugin manifest.
- Register the package runtime extension entry so the host can discover the plugin runtime consistently.

## Validation
- Parsed openclaw.plugin.json and package.json as JSON.