### PR TITLE
Let fetch set Weixin content length

### DIFF
--- a/src/api/api.ts
+++ b/src/api/api.ts
@@ -107,7 +107,6 @@ function buildHeaders(opts: { token?: string; body: string }): Record<string, st
   const headers: Record<string, string> = {
     "Content-Type": "application/json",
     AuthorizationType: "ilink_bot_token",
-    "Content-Length": String(Buffer.byteLength(opts.body, "utf-8")),
     "X-WECHAT-UIN": randomWechatUin(),
     ...buildCommonHeaders(),
   };


### PR DESCRIPTION
## Summary
- Stop setting Content-Length manually for JSON fetch requests.
- Let fetch compute the request body length so headers stay consistent with the encoded payload.

## Validation
- Inspected the request wrapper diff.
- Confirmed no other request headers were changed.