### PR TITLE
fix(monitor): plumb abortSignal into long-poll so channel stop honors gateway budget (#141)

### DIFF
--- a/src/api/api.test.ts
+++ b/src/api/api.test.ts
@@ -86,6 +86,59 @@ describe("getUpdates", () => {
     const [url] = mockFetch.mock.calls[0];
     expect(url).toContain("https://api.example.com/ilink/bot/getupdates");
   });
+
+  // Regression test for #141: when the gateway aborts the channel (e.g. during a
+  // config hot reload), the in-flight long-poll must be cancelled immediately
+  // so the monitor loop can exit within the gateway's 5s channel-stop budget.
+  it("forwards external abortSignal to the underlying fetch", async () => {
+    let receivedSignal: AbortSignal | undefined;
+    mockFetch.mockImplementationOnce((_url: string, opts: RequestInit) => {
+      receivedSignal = opts.signal as AbortSignal;
+      return new Promise<Response>((_resolve, reject) => {
+        // Mimic a long-poll: only resolve/reject when the signal aborts.
+        opts.signal?.addEventListener("abort", () => {
+          const e: Error & { name: string } = new Error("aborted");
+          e.name = "AbortError";
+          reject(e);
+        });
+      });
+    });
+
+    const external = new AbortController();
+    const pending = getUpdates({
+      baseUrl: "https://api.example.com",
+      get_updates_buf: "resume-buf",
+      timeoutMs: 60_000,
+      abortSignal: external.signal,
+    });
+    // Give the fetch a tick to register, then abort externally.
+    await new Promise((r) => setTimeout(r, 0));
+    external.abort();
+    const result = await pending;
+
+    expect(receivedSignal).toBeDefined();
+    expect(result.ret).toBe(0);
+    expect(result.get_updates_buf).toBe("resume-buf");
+  });
+
+  it("aborts immediately when external signal is already aborted", async () => {
+    let receivedSignal: AbortSignal | undefined;
+    mockFetch.mockImplementationOnce((_url: string, opts: RequestInit) => {
+      receivedSignal = opts.signal as AbortSignal;
+      const e: Error & { name: string } = new Error("aborted");
+      e.name = "AbortError";
+      return Promise.reject(e);
+    });
+
+    const external = new AbortController();
+    external.abort();
+    const result = await getUpdates({
+      baseUrl: "https://api.example.com",
+      abortSignal: external.signal,
+    });
+    expect(receivedSignal?.aborted).toBe(true);
+    expect(result.ret).toBe(0);
+  });
 });
 
 describe("getUploadUrl", () => {

--- a/src/api/api.ts
+++ b/src/api/api.ts
@@ -164,8 +164,39 @@ export async function apiGetFetch(params: {
 }
 
 /**
+ * Combine an internal timeout AbortController with an optional external AbortSignal
+ * (e.g. provided by the gateway when stopping a channel) so the underlying `fetch`
+ * is aborted as soon as either fires. Returns the signal to pass to `fetch` plus
+ * a `cleanup` function that releases the listener attached to the external signal.
+ */
+function combineAbortSignals(
+  internal: AbortController,
+  external: AbortSignal | undefined,
+): { signal: AbortSignal; cleanup: () => void } {
+  if (!external) return { signal: internal.signal, cleanup: () => {} };
+  // Forward an external abort to the internal controller so the existing
+  // `name === "AbortError"` handling kicks in uniformly.
+  if (external.aborted) {
+    internal.abort();
+    return { signal: internal.signal, cleanup: () => {} };
+  }
+  const onExternalAbort = () => internal.abort();
+  external.addEventListener("abort", onExternalAbort, { once: true });
+  return {
+    signal: internal.signal,
+    cleanup: () => external.removeEventListener("abort", onExternalAbort),
+  };
+}
+
+/**
  * Common fetch wrapper: POST JSON to a Weixin API endpoint with timeout + abort.
  * Returns the raw response text on success; throws on HTTP error or timeout.
+ *
+ * When `abortSignal` is provided, an external abort (e.g. gateway channel stop)
+ * cancels the in-flight request immediately instead of waiting for `timeoutMs`.
+ * Without this, a long-poll `getUpdates` would keep running until its own client
+ * timeout (~35s), well past the gateway's 5s channel-stop budget — which leaves
+ * the gateway unable to restart the channel after a config hot reload (#141).
  */
 async function apiPostFetch(params: {
   baseUrl: string;
@@ -174,6 +205,7 @@ async function apiPostFetch(params: {
   token?: string;
   timeoutMs: number;
   label: string;
+  abortSignal?: AbortSignal;
 }): Promise<string> {
   const base = ensureTrailingSlash(params.baseUrl);
   const url = new URL(params.endpoint, base);
@@ -182,14 +214,16 @@ async function apiPostFetch(params: {
 
   const controller = new AbortController();
   const t = setTimeout(() => controller.abort(), params.timeoutMs);
+  const { signal, cleanup } = combineAbortSignals(controller, params.abortSignal);
   try {
     const res = await fetch(url.toString(), {
       method: "POST",
       headers: hdrs,
       body: params.body,
-      signal: controller.signal,
+      signal,
     });
     clearTimeout(t);
+    cleanup();
     const rawText = await res.text();
     logger.debug(`${params.label} status=${res.status} raw=${redactBody(rawText)}`);
     if (!res.ok) {
@@ -198,6 +232,7 @@ async function apiPostFetch(params: {
     return rawText;
   } catch (err) {
     clearTimeout(t);
+    cleanup();
     throw err;
   }
 }
@@ -213,6 +248,13 @@ export async function getUpdates(
     baseUrl: string;
     token?: string;
     timeoutMs?: number;
+    /**
+     * Optional external abort signal (e.g. from the gateway when stopping the
+     * channel). When this aborts, the in-flight long-poll is terminated
+     * immediately so the monitor loop can exit well within the gateway's
+     * channel-stop budget (#141).
+     */
+    abortSignal?: AbortSignal;
   },
 ): Promise<GetUpdatesResp> {
   const timeout = params.timeoutMs ?? DEFAULT_LONG_POLL_TIMEOUT_MS;
@@ -227,13 +269,22 @@ export async function getUpdates(
       token: params.token,
       timeoutMs: timeout,
       label: "getUpdates",
+      abortSignal: params.abortSignal,
     });
     const resp: GetUpdatesResp = JSON.parse(rawText);
     return resp;
   } catch (err) {
-    // Long-poll timeout is normal; return empty response so caller can retry
+    // Long-poll timeout *or* external abort both surface as AbortError. The caller
+    // re-checks `abortSignal?.aborted` after we return; when aborted, it exits
+    // the loop. When not aborted (i.e. plain client-side long-poll timeout),
+    // returning the empty response lets the caller retry — preserving prior
+    // behavior for the normal long-poll case.
     if (err instanceof Error && err.name === "AbortError") {
-      logger.debug(`getUpdates: client-side timeout after ${timeout}ms, returning empty response`);
+      if (params.abortSignal?.aborted) {
+        logger.debug(`getUpdates: aborted by external signal`);
+      } else {
+        logger.debug(`getUpdates: client-side timeout after ${timeout}ms, returning empty response`);
+      }
       return { ret: 0, msgs: [], get_updates_buf: params.get_updates_buf };
     }
     throw err;

--- a/src/monitor/monitor.ts
+++ b/src/monitor/monitor.ts
@@ -95,6 +95,12 @@ export async function monitorWeixinProvider(opts: MonitorWeixinOpts): Promise<vo
         token,
         get_updates_buf: getUpdatesBuf,
         timeoutMs: nextTimeoutMs,
+        // Plumb the gateway's abort signal into the underlying fetch so a
+        // channel hot reload terminates the in-flight long-poll within ms
+        // (instead of waiting up to ~35s for the long-poll timeout). Without
+        // this, the gateway's channel-stop 5s budget is exceeded and the
+        // subsequent restart is skipped, leaving the Monitor stopped (#141).
+        abortSignal,
       });
       aLog.debug(
         `getUpdates response: ret=${resp.ret}, msgs=${resp.msgs?.length ?? 0}, get_updates_buf_length=${resp.get_updates_buf?.length ?? 0}`,


### PR DESCRIPTION
Fixes #141

## Summary

When the gateway hot-reloads the `openclaw-weixin` channel (any config change under `channels.openclaw-weixin.*`), the Monitor logs `Monitor ended` but never logs `Monitor started`, and the channel stays silent until a full `openclaw gateway restart`. This PR fixes that.

## Root Cause

The gateway lifecycle when a hot reload fires:

1. `stopChannel` calls `abort.abort()` on the channel's `AbortController` and awaits the channel task with a **5s grace budget**.
2. `startChannel` runs immediately afterwards.

The previous plugin code only checked `abortSignal?.aborted` **between** long-poll iterations:

```ts
while (!abortSignal?.aborted) {
  const resp = await getUpdates({ baseUrl, token, ..., timeoutMs: nextTimeoutMs });
  ...
}
```

The `getUpdates` fetch did **not** receive the external `abortSignal`. Its own `AbortController` only fires the **35s long-poll timeout**, so any in-flight `getUpdates` keeps running long past the gateway's 5s budget.

When that budget elapses the gateway logs:

```
[<account>] channel stop exceeded 5000ms after abort; continuing shutdown
```

and bails out of cleanup. The follow-up `startChannel` sees the old task still tracked and skips spawning a new monitor. Net effect: Monitor permanently stopped until a full gateway restart, exactly as @arlen8411 reproduced 3x in the issue.

## Fix

Forward the gateway-supplied `AbortSignal` all the way down into the `fetch()` backing `getUpdates`, so an external abort cancels the in-flight long-poll within milliseconds instead of waiting up to ~35s.

- `src/api/api.ts`
  - `apiPostFetch` now accepts an optional `abortSignal`. It combines the internal timeout `AbortController` with the external signal via a small helper (`combineAbortSignals`) and passes the unified signal to `fetch`.
  - `getUpdates` exposes a new optional `abortSignal` parameter and forwards it. The existing `name === "AbortError" -> empty response` behavior is preserved so plain client-side long-poll timeouts still trigger a normal retry (no behavior change for the happy path).
- `src/monitor/monitor.ts`
  - Pass the existing `abortSignal` from the gateway into `getUpdates`. The existing `while (!abortSignal?.aborted)` loop guard already does the right thing on the next iteration.
- `src/api/api.test.ts`
  - Two regression tests:
    - "forwards external abortSignal to the underlying fetch" — simulates an in-flight long-poll being interrupted externally.
    - "aborts immediately when external signal is already aborted" — covers the pre-aborted case.

## Test Plan

```bash
npm run typecheck   # ✓
npm run build       # ✓
npx vitest run      # 338 / 339 pass — the single failure is in
                    # src/auth/pairing.test.ts and reproduces on
                    # unmodified main; unrelated to this fix.
```

## Notes on Scope

There is a related latent bug in `openclaw` core: when `stopChannel`'s grace timeout fires, the new code path returns early without deleting the orphan entry from `store.tasks`, which is why `startChannelInternal`'s `if (store.tasks.has(id)) return;` short-circuits. That fix belongs in `openclaw/openclaw`, not here. The plugin-side change in this PR sidesteps the issue entirely by making sure the stop never exceeds the 5s budget in the first place — which is the correct cooperative-shutdown behavior for any channel plugin regardless of gateway internals.
