### PR TITLE
chore: shorten channel label from "openclaw-weixin" to "WeChat"

### DIFF
--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -10,7 +10,7 @@
         "type": "object",
         "additionalProperties": true
       },
-      "label": "openclaw-weixin",
+      "label": "WeChat",
       "description": "Weixin channel configuration."
     }
   },

--- a/package.json
+++ b/package.json
@@ -49,10 +49,10 @@
     ],
     "channel": {
       "id": "openclaw-weixin",
-      "label": "openclaw-weixin",
-      "selectionLabel": "openclaw-weixin",
+      "label": "WeChat",
+      "selectionLabel": "WeChat",
       "docsPath": "/channels/openclaw-weixin",
-      "docsLabel": "openclaw-weixin",
+      "docsLabel": "WeChat",
       "blurb": "Weixin channel",
       "order": 75
     },

--- a/src/channel.ts
+++ b/src/channel.ts
@@ -156,10 +156,10 @@ export const weixinPlugin: ChannelPlugin<ResolvedWeixinAccount> = {
   id: "openclaw-weixin",
   meta: {
     id: "openclaw-weixin",
-    label: "openclaw-weixin",
-    selectionLabel: "openclaw-weixin (long-poll)",
+    label: "WeChat",
+    selectionLabel: "WeChat (long-poll)",
     docsPath: "/channels/openclaw-weixin",
-    docsLabel: "openclaw-weixin",
+    docsLabel: "WeChat",
     blurb: "getUpdates long-poll upstream, sendMessage downstream; token auth.",
     order: 75,
   },


### PR DESCRIPTION
## Summary

Shorten the channel display label from `openclaw-weixin` to `WeChat` for a cleaner session list in Control UI.

### Problem

Session titles in Control UI are excessively long:
```
agent:main:openclaw-weixin:direct:o9cq80-pjknon-f6onuzhryb9siy@im.wechat
```

The `openclaw-weixin` segment comes from `meta.label` in the plugin. For comparison, Telegram and Discord plugins use short labels ("Telegram", "Discord").

### Changes

- `src/channel.ts`: `meta.label`, `meta.selectionLabel`, `meta.docsLabel` → "WeChat"
- `openclaw.plugin.json`: `channelConfigs.openclaw-weixin.label` → "WeChat"  
- `package.json`: `openclaw.channel.label`, `selectionLabel`, `docsLabel` → "WeChat"

The plugin `id` remains `openclaw-weixin` (no breaking change to config or session keys).

### Related

- openclaw/openclaw#83930 (upstream feature request for user-configurable channel labels)
