### PR TITLE
feat: isolate inbound media storage per agent

### DIFF
--- a/src/media/media-download.ts
+++ b/src/media/media-download.ts
@@ -29,12 +29,15 @@ export async function downloadMediaFromItem(
   deps: {
     cdnBaseUrl: string;
     saveMedia: SaveMediaFn;
+    /** Subdirectory under the media store (e.g. "wecom/<agentId>/inbound"). Defaults to "inbound". */
+    subdir?: string;
     log: (msg: string) => void;
     errLog: (msg: string) => void;
     label: string;
   },
 ): Promise<WeixinInboundMediaOpts> {
   const { cdnBaseUrl, saveMedia, log, errLog, label } = deps;
+  const subdir = deps.subdir ?? "inbound";
   const result: WeixinInboundMediaOpts = {};
 
   if (item.type === MessageItemType.IMAGE) {
@@ -61,7 +64,7 @@ export async function downloadMediaFromItem(
             `${label} image-plain`,
             img.media.full_url,
           );
-      const saved = await saveMedia(buf, undefined, "inbound", WEIXIN_MEDIA_MAX_BYTES);
+      const saved = await saveMedia(buf, undefined, subdir, WEIXIN_MEDIA_MAX_BYTES);
       result.decryptedPicPath = saved.path;
       logger.debug(`${label} image saved: ${saved.path}`);
     } catch (err) {
@@ -83,12 +86,12 @@ export async function downloadMediaFromItem(
       logger.debug(`${label} voice: decrypted ${silkBuf.length} bytes, attempting silk transcode`);
       const wavBuf = await silkToWav(silkBuf);
       if (wavBuf) {
-        const saved = await saveMedia(wavBuf, "audio/wav", "inbound", WEIXIN_MEDIA_MAX_BYTES);
+        const saved = await saveMedia(wavBuf, "audio/wav", subdir, WEIXIN_MEDIA_MAX_BYTES);
         result.decryptedVoicePath = saved.path;
         result.voiceMediaType = "audio/wav";
         logger.debug(`${label} voice: saved WAV to ${saved.path}`);
       } else {
-        const saved = await saveMedia(silkBuf, "audio/silk", "inbound", WEIXIN_MEDIA_MAX_BYTES);
+        const saved = await saveMedia(silkBuf, "audio/silk", subdir, WEIXIN_MEDIA_MAX_BYTES);
         result.decryptedVoicePath = saved.path;
         result.voiceMediaType = "audio/silk";
         logger.debug(`${label} voice: silk transcode unavailable, saved raw SILK to ${saved.path}`);
@@ -113,7 +116,7 @@ export async function downloadMediaFromItem(
       const saved = await saveMedia(
         buf,
         mime,
-        "inbound",
+        subdir,
         WEIXIN_MEDIA_MAX_BYTES,
         fileItem.file_name ?? undefined,
       );
@@ -136,7 +139,7 @@ export async function downloadMediaFromItem(
         `${label} video`,
         videoItem.media.full_url,
       );
-      const saved = await saveMedia(buf, "video/mp4", "inbound", WEIXIN_MEDIA_MAX_BYTES);
+      const saved = await saveMedia(buf, "video/mp4", subdir, WEIXIN_MEDIA_MAX_BYTES);
       result.decryptedVideoPath = saved.path;
       logger.debug(`${label} video: saved to ${saved.path}`);
     } catch (err) {

--- a/src/messaging/process-message.ts
+++ b/src/messaging/process-message.ts
@@ -60,8 +60,8 @@ function extractTextBody(itemList?: import("../api/types.js").MessageItem[]): st
 }
 
 /**
- * Process a single inbound message: route → download media → dispatch reply.
- * Extracted from the monitor loop to keep monitoring and message handling separate.
+ * Process a single inbound message: resolve route → download media → authorize → dispatch reply.
+ * Route is resolved first so agentId can isolate media per-agent in the media store.
  */
 export async function processOneMessage(
   full: WeixinMessage,
@@ -107,6 +107,35 @@ export async function processOneMessage(
     );
   }
 
+  // Resolve agent route early so we can use agentId for per-agent media isolation.
+  const senderId = full.from_user_id ?? "";
+  const route = deps.channelRuntime.routing.resolveAgentRoute({
+    cfg: deps.config,
+    channel: "openclaw-weixin",
+    accountId: deps.accountId,
+    peer: { kind: "direct", id: senderId },
+  });
+  logger.debug(
+    `resolveAgentRoute: agentId=${route.agentId ?? "(none)"} sessionKey=${route.sessionKey ?? "(none)"} mainSessionKey=${route.mainSessionKey ?? "(none)"}`,
+  );
+  if (!route.agentId) {
+    logger.error(
+      `resolveAgentRoute: no agentId resolved for peer=${senderId} accountId=${deps.accountId} — message will not be dispatched`,
+    );
+  }
+
+  if (debug) {
+    debugTrace.push(
+      "── 路由 ──",
+      `│ route: agent=${route.agentId ?? "none"} session=${route.sessionKey ?? "none"}`,
+    );
+  }
+
+  // Per-agent media isolation: wecom/<agentId>/inbound
+  const mediaSubdir = route.agentId
+    ? `wecom/${route.agentId}/inbound`
+    : "inbound";
+
   const mediaOpts: WeixinInboundMediaOpts = {};
 
   // Find the first downloadable media item (priority: IMAGE > VIDEO > FILE > VOICE).
@@ -145,6 +174,7 @@ export async function processOneMessage(
     const downloaded = await downloadMediaFromItem(mediaItem, {
       cdnBaseUrl: deps.cdnBaseUrl,
       saveMedia: deps.channelRuntime.media.saveMediaBuffer,
+      subdir: mediaSubdir,
       log: deps.log,
       errLog: deps.errLog,
       label,
@@ -165,8 +195,6 @@ export async function processOneMessage(
   // --- Framework command authorization ---
   const rawBody = ctx.Body?.trim() ?? "";
   ctx.CommandBody = rawBody;
-
-  const senderId = full.from_user_id ?? "";
 
   const { senderAllowedForCommands, commandAuthorized } =
     await resolveSenderCommandAuthorizationWithRuntime({
@@ -208,29 +236,8 @@ export async function processOneMessage(
 
   if (debug) {
     debugTrace.push(
-      "── 鉴权 & 路由 ──",
+      "── 鉴权 ──",
       `│ auth: cmdAuthorized=${String(commandAuthorized)} senderAllowed=${String(senderAllowedForCommands)}`,
-    );
-  }
-
-  const route = deps.channelRuntime.routing.resolveAgentRoute({
-    cfg: deps.config,
-    channel: "openclaw-weixin",
-    accountId: deps.accountId,
-    peer: { kind: "direct", id: ctx.To },
-  });
-  logger.debug(
-    `resolveAgentRoute: agentId=${route.agentId ?? "(none)"} sessionKey=${route.sessionKey ?? "(none)"} mainSessionKey=${route.mainSessionKey ?? "(none)"}`,
-  );
-  if (!route.agentId) {
-    logger.error(
-      `resolveAgentRoute: no agentId resolved for peer=${ctx.To} accountId=${deps.accountId} — message will not be dispatched`,
-    );
-  }
-
-  if (debug) {
-    debugTrace.push(
-      `│ route: agent=${route.agentId ?? "none"} session=${route.sessionKey ?? "none"}`,
     );
     debugTs.preDispatch = Date.now();
   }


### PR DESCRIPTION
## Problem

  All inbound media files (images, videos, files, voice) from WeChat users are saved to a single flat directory (`~/.openclaw/media/inbound/`). When multiple agents are configured, files from different agents are mixed together with no way to tell which agent received which file.

## Motivation

  I maintain an internal OpenClaw deployment for my company's IT department. Recently, many colleagues have started using OpenClaw with WeChat, and we encountered a critical issue:

  - Agent A receives a contract file from WeChat
  - Agent B receives an invoice file
  - Both files land in ~/.openclaw/media/inbound/
  - Agent A may read Agent B's file, causing confusion and potential data leakage

  I first tried to mitigate this via AGENTS.md rules, but that's fundamentally impossible — agents cannot be instructed to read from different folders when all files are co-located in a single flat directory.

  After debugging, I identified the root cause in the WeChat plugin. I also examined the DingTalk plugin, which already implements per-agent media isolation. This PR gives the WeChat plugin similar per-agent separation to what DingTalk already has.

  This fix would directly improve our production setup at work, and I believe many other multi-agent users would benefit as well.

## Why this approach

  The plugin uses OpenClaw's `channelRuntime.media.saveMediaBuffer` to persist inbound media. This SDK method manages the media store internally and does not expose the agent's workspace path — we cannot tell it to save directly to `~/.openclaw/agents/<id>/workspace`.

  The `saveMediaBuffer` API does accept a `subdir` parameter for organizing files within its media store. By resolving the agent route early and passing `wecom/<agentId>/inbound` as the subdirectory, we achieve per-agent file isolation with minimal code change — no SDK modification, no path traversal, no custom file copy logic.

## Changes

  - **`src/messaging/process-message.ts`**: Move `resolveAgentRoute` before the media download step (it only depends on `cfg`, `accountId`, and `from_user_id`,  all available before download). Construct `mediaSubdir` from the resolved `agentId` and pass it to `downloadMediaFromItem`.
  - **`src/media/media-download.ts`**: Accept an optional `subdir` parameter (defaults to `"inbound"` for backward compatibility). Use it instead of the
  hardcoded `"inbound"` in all `saveMedia` calls.

### Before

  ~/.openclaw/media/inbound/.png

### After

  ~/.openclaw/media/wecom/agentId/inbound/.png

## Notes

  - When `agentId` cannot be resolved, falls back to the original `"inbound"` directory.
  - No new tests needed — both changed files are excluded from coverage thresholds, and existing tests pass.

## Test Results

  - **366 passed, 6 failed** (372 total)
  - **19 test files passed, 5 failed** (24 total)
  - All 6 failures are **pre-existing** and unrelated to this change:

  | Test | Cause |
  |------|-------|
  | `state-dir.test.ts` > `resolveStateDir` > falls back to ~/.openclaw | Windows path separator (`\` vs `/`) |
  | `sync-buf.test.ts` > `getSyncBufFilePath` > returns path under accounts dir | Timeout (>5s) |
  | `account-index.test.ts` > `listIndexedWeixinAccountIds` > returns empty array when file does not exist | Timeout (>5s) |
  | `account-store.test.ts` > `loadWeixinAccount` > returns null when no account file exists | Timeout (>5s) |
  | `pairing.test.ts` > `resolveFrameworkAllowFromPath` > returns correct path | Timeout (>5s) |
  | `pairing.test.ts` > `registerUserInFrameworkStore` > uses withFileLock | Assertion (mock not called) |

  All failures are in `src/auth/` and `src/storage/` test files — none touch `src/messaging/` or `src/media/` where this change was made.