### PR TITLE
fix: pass ref_msg content as structured ReplyTo fields for inbound_meta

### DIFF
--- a/src/messaging/inbound.test.ts
+++ b/src/messaging/inbound.test.ts
@@ -253,6 +253,114 @@ describe("weixinMessageToMsgContext", () => {
   });
 });
 
+describe("ReplyTo fields (ref_msg → inbound_meta)", () => {
+  it("populates ReplyToIsQuote, ReplyToSender, ReplyToId, ReplyToBody from ref_msg", () => {
+    const msg: WeixinMessage = {
+      from_user_id: "u",
+      item_list: [
+        {
+          type: MessageItemType.TEXT,
+          text_item: { text: "my reply" },
+          ref_msg: {
+            title: "Author",
+            message_item: {
+              type: MessageItemType.TEXT,
+              msg_id: "quoted-msg-123",
+              text_item: { text: "original text" },
+            },
+          },
+        },
+      ],
+    };
+    const ctx = weixinMessageToMsgContext(msg, "acc");
+    expect(ctx.ReplyToIsQuote).toBe(true);
+    expect(ctx.ReplyToSender).toBe("Author");
+    expect(ctx.ReplyToId).toBe("quoted-msg-123");
+    expect(ctx.ReplyToBody).toBe("original text");
+  });
+
+  it("ReplyToBody excludes the title (ReplyToSender handles it separately)", () => {
+    const msg: WeixinMessage = {
+      from_user_id: "u",
+      item_list: [
+        {
+          type: MessageItemType.TEXT,
+          text_item: { text: "reply" },
+          ref_msg: {
+            title: "Sender Name",
+            message_item: {
+              type: MessageItemType.TEXT,
+              msg_id: "msg-456",
+              text_item: { text: "quoted body only" },
+            },
+          },
+        },
+      ],
+    };
+    const ctx = weixinMessageToMsgContext(msg, "acc");
+    expect(ctx.ReplyToSender).toBe("Sender Name");
+    // Body includes title for display, but ReplyToBody is body-only
+    expect(ctx.ReplyToBody).toBe("quoted body only");
+    expect(ctx.Body).toBe("[引用: Sender Name | quoted body only]\nreply");
+  });
+
+  it("does not set ReplyTo* when no ref_msg", () => {
+    const msg: WeixinMessage = {
+      from_user_id: "u",
+      item_list: [
+        { type: MessageItemType.TEXT, text_item: { text: "plain msg" } },
+      ],
+    };
+    const ctx = weixinMessageToMsgContext(msg, "acc");
+    expect(ctx.ReplyToIsQuote).toBeUndefined();
+    expect(ctx.ReplyToSender).toBeUndefined();
+    expect(ctx.ReplyToId).toBeUndefined();
+    expect(ctx.ReplyToBody).toBeUndefined();
+  });
+
+  it("ReplyToBody is undefined when ref_msg is a media item", () => {
+    const msg: WeixinMessage = {
+      from_user_id: "u",
+      item_list: [
+        {
+          type: MessageItemType.TEXT,
+          text_item: { text: "check this" },
+          ref_msg: {
+            title: "Author",
+            message_item: { type: MessageItemType.IMAGE },
+          },
+        },
+      ],
+    };
+    const ctx = weixinMessageToMsgContext(msg, "acc");
+    expect(ctx.ReplyToIsQuote).toBe(true);
+    expect(ctx.ReplyToSender).toBe("Author");
+    expect(ctx.ReplyToBody).toBeUndefined(); // media → no extractable body
+  });
+
+  it("ReplyToId is undefined when quoted message_item has no msg_id", () => {
+    const msg: WeixinMessage = {
+      from_user_id: "u",
+      item_list: [
+        {
+          type: MessageItemType.TEXT,
+          text_item: { text: "reply" },
+          ref_msg: {
+            title: "Author",
+            message_item: {
+              type: MessageItemType.TEXT,
+              text_item: { text: "no msg id" },
+              // no msg_id field
+            },
+          },
+        },
+      ],
+    };
+    const ctx = weixinMessageToMsgContext(msg, "acc");
+    expect(ctx.ReplyToId).toBeUndefined();
+  });
+});
+
 describe("getContextTokenFromMsgContext", () => {
   it("returns context_token when present", () => {
     const ctx = { context_token: "tok123" } as WeixinMsgContext;

--- a/src/messaging/inbound.ts
+++ b/src/messaging/inbound.ts
@@ -157,6 +157,14 @@ export type WeixinMsgContext = {
   CommandBody?: string;
   /** Whether the sender is authorized to execute slash commands. */
   CommandAuthorized?: boolean;
+  /** Body of the message being replied to (quoted/ref_msg). */
+  ReplyToBody?: string;
+  /** Message ID of the message being replied to (quoted/ref_msg). */
+  ReplyToId?: string;
+  /** Sender label of the message being replied to (quoted/ref_msg title). */
+  ReplyToSender?: string;
+  /** Whether the reply is a quote (true for ref_msg). */
+  ReplyToIsQuote?: boolean;
 };
 
 /** Returns true if the message item is a media type (image, video, file, or voice). */
@@ -169,6 +177,21 @@ export function isMediaItem(item: MessageItem): boolean {
   );
 }
 
+/**
+ * Extract the quoted/reference message content from a TEXT item's ref_msg.
+ * Returns the quoted body text, or undefined if no ref_msg content is extractable.
+ */
+function extractRefBody(ref: NonNullable<MessageItem["ref_msg"]>): string | undefined {
+  if (ref.message_item && isMediaItem(ref.message_item)) return undefined;
+  const parts: string[] = [];
+  if (ref.title) parts.push(ref.title);
+  if (ref.message_item) {
+    const refBody = bodyFromItemList([ref.message_item]);
+    if (refBody) parts.push(refBody);
+  }
+  return parts.length > 0 ? parts.join(" | ") : undefined;
+}
+
 function bodyFromItemList(itemList?: MessageItem[]): string {
   if (!itemList?.length) return "";
   for (const item of itemList) {
@@ -176,17 +199,9 @@ function bodyFromItemList(itemList?: MessageItem[]): string {
       const text = String(item.text_item.text);
       const ref = item.ref_msg;
       if (!ref) return text;
-      // Quoted media is passed as MediaPath; only include the current text as body.
-      if (ref.message_item && isMediaItem(ref.message_item)) return text;
-      // Build quoted context from both title and message_item content.
-      const parts: string[] = [];
-      if (ref.title) parts.push(ref.title);
-      if (ref.message_item) {
-        const refBody = bodyFromItemList([ref.message_item]);
-        if (refBody) parts.push(refBody);
-      }
-      if (!parts.length) return text;
-      return `[引用: ${parts.join(" | ")}]\n${text}`;
+      const refBody = extractRefBody(ref);
+      if (!refBody) return text;
+      return `[引用: ${refBody}]\n${text}`;
     }
     // 语音转文字：如果语音消息有 text 字段，直接使用文字内容
     if (item.type === MessageItemType.VOICE && item.voice_item?.text) {
@@ -210,6 +225,20 @@ export type WeixinInboundMediaOpts = {
   /** Local path to decrypted video file. */
   decryptedVideoPath?: string;
 };
+
+/**
+ * Find the first ref_msg across all TEXT items in the message item list.
+ * Returns the ref_msg field or undefined if none is found.
+ */
+function findRefMsg(itemList?: MessageItem[]): NonNullable<MessageItem["ref_msg"]> | undefined {
+  if (!itemList?.length) return undefined;
+  for (const item of itemList) {
+    if (item.type === MessageItemType.TEXT && item.ref_msg) {
+      return item.ref_msg;
+    }
+  }
+  return undefined;
+}
 
 /**
  * Convert a WeixinMessage from getUpdates to the inbound MsgContext for the core pipeline.
@@ -237,6 +266,20 @@ export function weixinMessageToMsgContext(
   };
   if (msg.context_token) {
     ctx.context_token = msg.context_token;
+  }
+
+  // Populate ReplyTo* fields from ref_msg so the framework includes
+  // the quoted message in inbound_meta (untrusted reply target block).
+  const refMsg = findRefMsg(msg.item_list);
+  if (refMsg) {
+    ctx.ReplyToIsQuote = true;
+    ctx.ReplyToSender = refMsg.title?.trim() || undefined;
+    ctx.ReplyToId = refMsg.message_item?.msg_id || undefined;
+    // ReplyToBody: only the quoted body text, not the sender title
+    // (ReplyToSender already carries the title separately).
+    if (refMsg.message_item && !isMediaItem(refMsg.message_item)) {
+      ctx.ReplyToBody = bodyFromItemList([refMsg.message_item]) || undefined;
+    }
   }
 
   if (opts?.decryptedPicPath) {


### PR DESCRIPTION
## Summary

When a user sends a message that quotes another message (ref_msg), the plugin previously only prepended the quoted content as `[引用: ...]` prefix in the Body text. This meant the quoted content did **not** appear in the framework's structured `inbound_meta` (untrusted reply target block) that `buildInboundUserContextPrefix()` generates from `ReplyToBody` / `ReplyToId` fields.

## Root Cause

The `weixinMessageToMsgContext()` function extracted `ref_msg` content solely into the Body text prefix. The OpenClaw core framework uses `MsgContext` fields like `ReplyToBody`, `ReplyToId`, `ReplyToSender`, `ReplyToIsQuote` to include the quoted message as a structured "Reply target of current user message (untrusted, for context)" block in the agent's `inbound_meta`. These fields were never populated by the weixin plugin.

## Changes

- Add `ReplyToBody`, `ReplyToId`, `ReplyToSender`, `ReplyToIsQuote` fields to `WeixinMsgContext` type
- Extract `ref_msg` content and populate these fields in `weixinMessageToMsgContext()` so the framework includes the quoted message in the untrusted reply target metadata block
- Refactor: extract `extractRefBody()` helper from `bodyFromItemList()` to eliminate duplicated ref_msg content extraction logic

## Verification

- `npm run build` — clean
- `npm test` — 396/397 pass (1 pre-existing Windows path separator issue in `state-dir.test.ts`)
- Inbound tests (`src/messaging/inbound.test.ts`) — all 25 pass
- TypeScript: `tsc --noEmit` — clean

Closes #222
