### PR TITLE
Fix case-sensitive Weixin peer route matching

### DIFF
--- a/src/messaging/process-message.ts
+++ b/src/messaging/process-message.ts
@@ -216,11 +216,12 @@ export async function processOneMessage(
     );
   }
 
+  const routePeerId = ctx.To.toLowerCase();
   const route = deps.channelRuntime.routing.resolveAgentRoute({
     cfg: deps.config,
     channel: "openclaw-weixin",
     accountId: deps.accountId,
-    peer: { kind: "direct", id: ctx.To },
+    peer: { kind: "direct", id: routePeerId },
   });
   logger.debug(
     `resolveAgentRoute: agentId=${route.agentId ?? "(none)"} sessionKey=${route.sessionKey ?? "(none)"} mainSessionKey=${route.mainSessionKey ?? "(none)"}`,
@@ -260,7 +261,7 @@ export async function processOneMessage(
     updateLastRoute: {
       sessionKey: route.mainSessionKey,
       channel: "openclaw-weixin",
-      to: ctx.To,
+      to: routePeerId,
       accountId: deps.accountId,
     },
     onRecordError: (err) => deps.errLog(`recordInboundSession: ${String(err)}`),


### PR DESCRIPTION
## What changed

- Normalize the inbound Weixin peer ID to lowercase before resolving an OpenClaw agent route.
- Reuse that canonical peer ID when recording `lastRoute.to`.
- Preserve the original `ctx.To` for outbound delivery.

## Why

Weixin may provide the same peer identifier with mixed-case characters while an OpenClaw binding stores its lowercase form. The exact route matcher then misses the intended binding and falls back to the default agent.

All identifiers used during validation were kept private; examples in the related issue are synthetic.

Fixes #232.

## Validation

- `npm run typecheck`
- `npm run build`
- `OPENCLAW_STATE_DIR=<temporary directory> npx vitest run --coverage=false` — 397/397 tests passed
- Live local validation on plugin 2.4.6 confirmed that a mixed-case inbound peer matched the existing lowercase binding and did not affect the Telegram route.

The repository's coverage command executes all 397 tests successfully but currently reports global branch coverage of 89.13% against its configured 90% threshold; `process-message.ts` is excluded from coverage, so this patch does not change that metric.
