### PR TITLE
fix(messaging): dedupe short-window getUpdates inbound replays

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@
 
 This project follows the [Keep a Changelog](https://keepachangelog.com/) format.
 
+## [Unreleased]
+
+### Fixed
+
+- **Inbound getUpdates duplicate delivery:** `processOneMessage` now claims a short-TTL dedupe key (`message_id` → `client_id` → `seq` → body fingerprint) before any side effects, so at-least-once iLink long-poll replays (~1s) no longer run the AI pipeline twice. `MessageSid` is derived from the same stable key when transport ids are present.
+
 ## [2.4.5] - 2026-06-22
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ This project follows the [Keep a Changelog](https://keepachangelog.com/) format.
 
 ### Fixed
 
-- **Inbound getUpdates duplicate delivery:** `processOneMessage` now claims a short-TTL dedupe key (`message_id` → `client_id` → `seq` → body fingerprint) before any side effects, so at-least-once iLink long-poll replays (~1s) no longer run the AI pipeline twice. `MessageSid` is derived from the same stable key when transport ids are present.
+- **Inbound getUpdates duplicate delivery:** `processOneMessage` now claims a short-TTL dedupe key (`message_id` → `client_id` → `seq` → body fingerprint) before any side effects, so at-least-once iLink long-poll replays (~1s) no longer run the AI pipeline twice. `MessageSid` is derived from the same stable key when transport ids are present. The **5-minute window is a replay-dedupe window** (same transport id / same claim key from getUpdates at-least-once delivery), **not** a “message dedupe window” that drops a user intentionally sending the same text again with a new `message_id`. In-memory claim is **single-process only** (current deploy assumption: one gateway instance per account).
 
 ## [2.4.5] - 2026-06-22
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ This project follows the [Keep a Changelog](https://keepachangelog.com/) format.
 
 ### Fixed
 
-- **Inbound getUpdates duplicate delivery:** `processOneMessage` now claims a short-TTL dedupe key (`message_id` → `client_id` → `seq` → body fingerprint) before any side effects, so at-least-once iLink long-poll replays (~1s) no longer run the AI pipeline twice. `MessageSid` is derived from the same stable key when transport ids are present. The **5-minute window is a replay-dedupe window** (same transport id / same claim key from getUpdates at-least-once delivery), **not** a “message dedupe window” that drops a user intentionally sending the same text again with a new `message_id`. In-memory claim is **single-process only** (current deploy assumption: one gateway instance per account).
+- **Inbound getUpdates duplicate delivery:** `processOneMessage` claims a stable dedupe key (`message_id` → `client_id` → `seq` → body fingerprint) via OpenClaw `createClaimableDedupe` before any side effects, then **commits a disk tombstone** under `$OPENCLAW_STATE_DIR/openclaw-weixin/replay-dedupe/` so at-least-once iLink long-poll replays (~1s) and longer redeliveries (e.g. 30–50 min after a stuck long turn) do not run the AI pipeline twice — including across process restart. `MessageSid` uses the same key when transport ids are present. The **24-hour window is a replay-dedupe / tombstone window** (same transport id / claim key), **not** a “message dedupe window” that drops a user intentionally sending the same text again with a new `message_id`. Multi-replica gateways still need a shared store / ingress drain (out of scope).
 
 ## [2.4.5] - 2026-06-22
 

--- a/CHANGELOG.zh_CN.md
+++ b/CHANGELOG.zh_CN.md
@@ -8,7 +8,7 @@
 
 ### 修复
 
-- **入站 getUpdates 双投递：** `processOneMessage` 在任何副作用之前按短 TTL 去重键认领消息（`message_id` → `client_id` → `seq` → 正文指纹），避免 iLink 长轮询至少一次投递（约 1 秒内重放）把同一条用户消息跑两遍 AI。`MessageSid` 在存在传输层 id 时使用同一稳定键。
+- **入站 getUpdates 双投递：** `processOneMessage` 在任何副作用之前按短 TTL 去重键认领消息（`message_id` → `client_id` → `seq` → 正文指纹），避免 iLink 长轮询至少一次投递（约 1 秒内重放）把同一条用户消息跑两遍 AI。`MessageSid` 在存在传输层 id 时使用同一稳定键。**5 分钟是「重放去重窗口」**（同一传输层 id / 同一 claim key 的 getUpdates 至少一次投递），**不是**「消息去重窗口」——用户故意再发一条相同正文、但带有新 `message_id` 的消息不会被吞。内存 claim **仅单进程有效**（当前部署假设：每账号单网关实例）。
 
 ## [2.4.5] - 2026-06-22
 

--- a/CHANGELOG.zh_CN.md
+++ b/CHANGELOG.zh_CN.md
@@ -4,6 +4,12 @@
 
 本项目遵循 [Keep a Changelog](https://keepachangelog.com/) 格式。
 
+## [Unreleased]
+
+### 修复
+
+- **入站 getUpdates 双投递：** `processOneMessage` 在任何副作用之前按短 TTL 去重键认领消息（`message_id` → `client_id` → `seq` → 正文指纹），避免 iLink 长轮询至少一次投递（约 1 秒内重放）把同一条用户消息跑两遍 AI。`MessageSid` 在存在传输层 id 时使用同一稳定键。
+
 ## [2.4.5] - 2026-06-22
 
 ### 新增

--- a/CHANGELOG.zh_CN.md
+++ b/CHANGELOG.zh_CN.md
@@ -8,7 +8,7 @@
 
 ### 修复
 
-- **入站 getUpdates 双投递：** `processOneMessage` 在任何副作用之前按短 TTL 去重键认领消息（`message_id` → `client_id` → `seq` → 正文指纹），避免 iLink 长轮询至少一次投递（约 1 秒内重放）把同一条用户消息跑两遍 AI。`MessageSid` 在存在传输层 id 时使用同一稳定键。**5 分钟是「重放去重窗口」**（同一传输层 id / 同一 claim key 的 getUpdates 至少一次投递），**不是**「消息去重窗口」——用户故意再发一条相同正文、但带有新 `message_id` 的消息不会被吞。内存 claim **仅单进程有效**（当前部署假设：每账号单网关实例）。
+- **入站 getUpdates 双投递：** `processOneMessage` 在任何副作用之前用 OpenClaw `createClaimableDedupe` 认领稳定去重键（`message_id` → `client_id` → `seq` → 正文指纹），处理完成后在 `$OPENCLAW_STATE_DIR/openclaw-weixin/replay-dedupe/` **落盘墓碑**，避免 iLink 长轮询至少一次投递（约 1 秒重放）以及更长窗口重投（例如长任务卡住后的 30–50 分钟）把同一条用户消息跑两遍 AI，并在进程重启后仍生效。`MessageSid` 在存在传输层 id 时使用同一稳定键。**24 小时是「重放去重 / 墓碑窗口」**（同一传输层 id / claim key），**不是**「消息去重窗口」——用户故意再发一条相同正文、但带有新 `message_id` 的消息不会被吞。多副本网关仍需共享存储 / ingress drain（本 PR 不做）。
 
 ## [2.4.5] - 2026-06-22
 

--- a/src/messaging/inbound-dedupe.test.ts
+++ b/src/messaging/inbound-dedupe.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import type { WeixinMessage } from "../api/types.js";
 import { MessageItemType } from "../api/types.js";
@@ -6,7 +6,9 @@ import {
   WEIXIN_INBOUND_DEDUPE_TTL_MS,
   buildWeixinInboundDedupeKey,
   claimWeixinInboundMessage,
+  commitWeixinInboundMessage,
   logWeixinInboundDuplicate,
+  releaseWeixinInboundMessage,
   resetWeixinInboundDedupeForTests,
 } from "./inbound-dedupe.js";
 import { logger } from "../util/logger.js";
@@ -19,6 +21,10 @@ vi.mock("../util/logger.js", () => ({
     error: vi.fn(),
   },
 }));
+
+beforeEach(() => {
+  resetWeixinInboundDedupeForTests();
+});
 
 afterEach(() => {
   resetWeixinInboundDedupeForTests();
@@ -62,30 +68,10 @@ describe("buildWeixinInboundDedupeKey", () => {
     );
     expect(bodyKey).toMatch(/^weixin:v1:jinjin:user-1:body:[0-9a-f]{16}$/);
   });
-});
-
-describe("claimWeixinInboundMessage", () => {
-  it("claims once and rejects short-window duplicates", () => {
-    const key = buildWeixinInboundDedupeKey("jinjin", textMsg())!;
-    const t0 = 1_000_000;
-    expect(claimWeixinInboundMessage(key, t0)).toBe(true);
-    expect(claimWeixinInboundMessage(key, t0 + 900)).toBe(false);
-    expect(claimWeixinInboundMessage(key, t0 + WEIXIN_INBOUND_DEDUPE_TTL_MS + 1)).toBe(true);
-  });
 
   it("returns null key only when empty identity", () => {
     expect(buildWeixinInboundDedupeKey("", {})).toBeNull();
     expect(buildWeixinInboundDedupeKey("acc", {})).toBeNull();
-  });
-
-  it("prunes by dropping oldest half when over capacity", () => {
-    const t0 = 2_000_000;
-    for (let i = 0; i < 20_001; i++) {
-      expect(claimWeixinInboundMessage(`k-${i}`, t0 + i)).toBe(true);
-    }
-    // Still functional after hard-cap prune
-    expect(claimWeixinInboundMessage("fresh-after-cap", t0 + 30_000)).toBe(true);
-    expect(claimWeixinInboundMessage("fresh-after-cap", t0 + 30_100)).toBe(false);
   });
 
   it("body fallback uses voice transcription text", () => {
@@ -95,6 +81,52 @@ describe("claimWeixinInboundMessage", () => {
       item_list: [{ type: MessageItemType.VOICE, voice_item: { text: "语音转写" } }],
     });
     expect(key).toMatch(/^weixin:v1:acc:u:body:[0-9a-f]{16}$/);
+  });
+});
+
+describe("claimWeixinInboundMessage", () => {
+  it("claims once, rejects in-flight/duplicate, allows after TTL", async () => {
+    const key = buildWeixinInboundDedupeKey("jinjin", textMsg())!;
+    const t0 = 1_000_000;
+    const ns = { namespace: "jinjin", now: t0 };
+
+    expect(await claimWeixinInboundMessage(key, ns)).toBe(true);
+    // Second delivery while first is still in-flight
+    expect(await claimWeixinInboundMessage(key, { ...ns, now: t0 + 900 })).toBe(false);
+
+    await commitWeixinInboundMessage(key, ns);
+    // After commit, still within TTL
+    expect(await claimWeixinInboundMessage(key, { ...ns, now: t0 + 60_000 })).toBe(false);
+
+    // Past 24h replay tombstone window
+    expect(
+      await claimWeixinInboundMessage(key, {
+        namespace: "jinjin",
+        now: t0 + WEIXIN_INBOUND_DEDUPE_TTL_MS + 1,
+      }),
+    ).toBe(true);
+  });
+
+  it("release allows retry after failure", async () => {
+    const key = buildWeixinInboundDedupeKey("jinjin", textMsg())!;
+    const ns = { namespace: "jinjin", now: 1_000_000 };
+
+    expect(await claimWeixinInboundMessage(key, ns)).toBe(true);
+    releaseWeixinInboundMessage(key, { ...ns, error: new Error("boom") });
+    expect(await claimWeixinInboundMessage(key, ns)).toBe(true);
+  });
+
+  it("covers long-turn redelivery window (30–50 min)", async () => {
+    const key = buildWeixinInboundDedupeKey("jinjin", textMsg())!;
+    const t0 = 5_000_000;
+    expect(await claimWeixinInboundMessage(key, { namespace: "jinjin", now: t0 })).toBe(true);
+    await commitWeixinInboundMessage(key, { namespace: "jinjin", now: t0 });
+    expect(
+      await claimWeixinInboundMessage(key, {
+        namespace: "jinjin",
+        now: t0 + 50 * 60 * 1000,
+      }),
+    ).toBe(false);
   });
 });
 

--- a/src/messaging/inbound-dedupe.test.ts
+++ b/src/messaging/inbound-dedupe.test.ts
@@ -1,0 +1,114 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import type { WeixinMessage } from "../api/types.js";
+import { MessageItemType } from "../api/types.js";
+import {
+  WEIXIN_INBOUND_DEDUPE_TTL_MS,
+  buildWeixinInboundDedupeKey,
+  claimWeixinInboundMessage,
+  logWeixinInboundDuplicate,
+  resetWeixinInboundDedupeForTests,
+} from "./inbound-dedupe.js";
+import { logger } from "../util/logger.js";
+
+vi.mock("../util/logger.js", () => ({
+  logger: {
+    info: vi.fn(),
+    debug: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+afterEach(() => {
+  resetWeixinInboundDedupeForTests();
+});
+
+function textMsg(overrides: Partial<WeixinMessage> = {}): WeixinMessage {
+  return {
+    from_user_id: "user-1",
+    message_id: 42,
+    create_time_ms: 1_700_000_000_000,
+    item_list: [{ type: MessageItemType.TEXT, text_item: { text: "你好" } }],
+    ...overrides,
+  };
+}
+
+describe("buildWeixinInboundDedupeKey", () => {
+  it("prefers message_id", () => {
+    expect(buildWeixinInboundDedupeKey("jinjin", textMsg())).toBe(
+      "weixin:v1:jinjin:user-1:mid:42",
+    );
+  });
+
+  it("falls back to client_id then seq then body fingerprint", () => {
+    expect(
+      buildWeixinInboundDedupeKey(
+        "jinjin",
+        textMsg({ message_id: undefined, client_id: "c-9" }),
+      ),
+    ).toBe("weixin:v1:jinjin:user-1:cid:c-9");
+
+    expect(
+      buildWeixinInboundDedupeKey(
+        "jinjin",
+        textMsg({ message_id: undefined, client_id: undefined, seq: 7 }),
+      ),
+    ).toBe("weixin:v1:jinjin:user-1:seq:7");
+
+    const bodyKey = buildWeixinInboundDedupeKey(
+      "jinjin",
+      textMsg({ message_id: undefined, client_id: undefined, seq: undefined }),
+    );
+    expect(bodyKey).toMatch(/^weixin:v1:jinjin:user-1:body:[0-9a-f]{16}$/);
+  });
+});
+
+describe("claimWeixinInboundMessage", () => {
+  it("claims once and rejects short-window duplicates", () => {
+    const key = buildWeixinInboundDedupeKey("jinjin", textMsg())!;
+    const t0 = 1_000_000;
+    expect(claimWeixinInboundMessage(key, t0)).toBe(true);
+    expect(claimWeixinInboundMessage(key, t0 + 900)).toBe(false);
+    expect(claimWeixinInboundMessage(key, t0 + WEIXIN_INBOUND_DEDUPE_TTL_MS + 1)).toBe(true);
+  });
+
+  it("returns null key only when empty identity", () => {
+    expect(buildWeixinInboundDedupeKey("", {})).toBeNull();
+    expect(buildWeixinInboundDedupeKey("acc", {})).toBeNull();
+  });
+
+  it("prunes by dropping oldest half when over capacity", () => {
+    const t0 = 2_000_000;
+    for (let i = 0; i < 20_001; i++) {
+      expect(claimWeixinInboundMessage(`k-${i}`, t0 + i)).toBe(true);
+    }
+    // Still functional after hard-cap prune
+    expect(claimWeixinInboundMessage("fresh-after-cap", t0 + 30_000)).toBe(true);
+    expect(claimWeixinInboundMessage("fresh-after-cap", t0 + 30_100)).toBe(false);
+  });
+
+  it("body fallback uses voice transcription text", () => {
+    const key = buildWeixinInboundDedupeKey("acc", {
+      from_user_id: "u",
+      create_time_ms: 1,
+      item_list: [{ type: MessageItemType.VOICE, voice_item: { text: "语音转写" } }],
+    });
+    expect(key).toMatch(/^weixin:v1:acc:u:body:[0-9a-f]{16}$/);
+  });
+});
+
+describe("logWeixinInboundDuplicate", () => {
+  it("logs account and key", () => {
+    logWeixinInboundDuplicate({
+      accountId: "jinjin",
+      key: "weixin:v1:jinjin:u:mid:1",
+      messageId: 1,
+      seq: 2,
+      from: "u",
+    });
+    expect(logger.info).toHaveBeenCalledWith(
+      expect.stringContaining("dropping duplicate inbound message"),
+    );
+  });
+});

--- a/src/messaging/inbound-dedupe.ts
+++ b/src/messaging/inbound-dedupe.ts
@@ -1,0 +1,101 @@
+import { createHash } from "node:crypto";
+
+import type { MessageItem, WeixinMessage } from "../api/types.js";
+import { MessageItemType } from "../api/types.js";
+import { logger } from "../util/logger.js";
+
+/** Drop short-window getUpdates replays (~1s typical); keep a few minutes for retries. */
+export const WEIXIN_INBOUND_DEDUPE_TTL_MS = 5 * 60 * 1000;
+const WEIXIN_INBOUND_DEDUPE_MAX_ENTRIES = 20_000;
+
+const seenAt = new Map<string, number>();
+
+function extractTextForFallback(itemList?: MessageItem[]): string {
+  if (!itemList?.length) return "";
+  for (const item of itemList) {
+    if (item.type === MessageItemType.TEXT && item.text_item?.text != null) {
+      return String(item.text_item.text);
+    }
+    if (item.type === MessageItemType.VOICE && item.voice_item?.text) {
+      return String(item.voice_item.text);
+    }
+  }
+  return "";
+}
+
+/**
+ * Stable inbound identity for dedupe + MessageSid.
+ * Prefer transport ids from iLink; fall back to content fingerprint.
+ */
+export function buildWeixinInboundDedupeKey(
+  accountId: string,
+  msg: WeixinMessage,
+): string | null {
+  const from = msg.from_user_id ?? "";
+  if (!accountId) return null;
+
+  if (msg.message_id != null && Number.isFinite(msg.message_id)) {
+    return `weixin:v1:${accountId}:${from}:mid:${msg.message_id}`;
+  }
+  if (msg.client_id) {
+    return `weixin:v1:${accountId}:${from}:cid:${msg.client_id}`;
+  }
+  if (msg.seq != null && Number.isFinite(msg.seq)) {
+    return `weixin:v1:${accountId}:${from}:seq:${msg.seq}`;
+  }
+
+  const body = extractTextForFallback(msg.item_list);
+  const t = msg.create_time_ms ?? 0;
+  if (!from && !body && !t) return null;
+  const digest = createHash("sha256")
+    .update(body)
+    .update("\0")
+    .update(String(t))
+    .digest("hex")
+    .slice(0, 16);
+  return `weixin:v1:${accountId}:${from}:body:${digest}`;
+}
+
+function pruneExpired(now: number): void {
+  for (const [key, at] of seenAt) {
+    if (now - at > WEIXIN_INBOUND_DEDUPE_TTL_MS) seenAt.delete(key);
+  }
+  if (seenAt.size <= WEIXIN_INBOUND_DEDUPE_MAX_ENTRIES) return;
+  // Hard cap: drop oldest half when overflowing.
+  const entries = [...seenAt.entries()].sort((a, b) => a[1] - b[1]);
+  const drop = Math.ceil(entries.length / 2);
+  for (let i = 0; i < drop; i++) {
+    seenAt.delete(entries[i]![0]);
+  }
+}
+
+/**
+ * Claim a logical inbound message for processing.
+ * @returns true if this is the first claim (process it); false if a duplicate within TTL.
+ */
+export function claimWeixinInboundMessage(key: string, now = Date.now()): boolean {
+  pruneExpired(now);
+  const prev = seenAt.get(key);
+  if (prev != null && now - prev <= WEIXIN_INBOUND_DEDUPE_TTL_MS) {
+    return false;
+  }
+  seenAt.set(key, now);
+  return true;
+}
+
+/** Test helper — clears the in-memory cache. */
+export function resetWeixinInboundDedupeForTests(): void {
+  seenAt.clear();
+}
+
+export function logWeixinInboundDuplicate(params: {
+  accountId: string;
+  key: string;
+  messageId?: number;
+  seq?: number;
+  from?: string;
+}): void {
+  logger.info(
+    `[weixin] dropping duplicate inbound message account=${params.accountId} key=${params.key} msgId=${params.messageId ?? "?"} seq=${params.seq ?? "?"} from=${params.from ?? "?"}`,
+  );
+}

--- a/src/messaging/inbound-dedupe.ts
+++ b/src/messaging/inbound-dedupe.ts
@@ -1,19 +1,62 @@
 import { createHash } from "node:crypto";
+import path from "node:path";
+
+import { createClaimableDedupe } from "openclaw/plugin-sdk/persistent-dedupe";
+import { resolveStateDir } from "openclaw/plugin-sdk/state-paths";
 
 import type { MessageItem, WeixinMessage } from "../api/types.js";
 import { MessageItemType } from "../api/types.js";
 import { logger } from "../util/logger.js";
 
 /**
- * Replay-dedupe TTL for getUpdates at-least-once delivery (~1s typical spacing).
- * Not a content-dedupe window: a new user send with a new message_id is always claimed.
- * In-memory Map — single process only; multi-instance gateways need a shared store (out of scope).
+ * Replay-dedupe tombstone TTL for getUpdates at-least-once delivery.
+ * Covers ~1s iLink replays and longer redeliveries (e.g. 30–50 min after a
+ * stuck long turn). Not a content-dedupe window: a new user send with a new
+ * `message_id` is always claimed. Body-fingerprint keys include create_time_ms.
+ *
+ * Backed by `createClaimableDedupe` (memory + disk under OPENCLAW_STATE_DIR),
+ * so claims survive process restart. Concurrent multi-replica gateways still
+ * need a shared store / ingress drain (out of scope).
  */
-export const WEIXIN_INBOUND_DEDUPE_TTL_MS = 5 * 60 * 1000;
-const WEIXIN_INBOUND_DEDUPE_MAX_ENTRIES = 20_000;
+export const WEIXIN_INBOUND_DEDUPE_TTL_MS = 24 * 60 * 60 * 1000;
+const WEIXIN_INBOUND_DEDUPE_MEMORY_MAX = 20_000;
+const WEIXIN_INBOUND_DEDUPE_FILE_MAX = 20_000;
 
-/** Process-local claim store (single-instance deploy). */
-const seenAt = new Map<string, number>();
+function sanitizeSegment(value: string): string {
+  const trimmed = value.trim();
+  if (!trimmed) return "global";
+  return trimmed.replace(/[^a-zA-Z0-9_-]/g, "_");
+}
+
+function createWeixinInboundDedupe(options?: { stateDir?: string | null }) {
+  const base = {
+    ttlMs: WEIXIN_INBOUND_DEDUPE_TTL_MS,
+    memoryMaxSize: WEIXIN_INBOUND_DEDUPE_MEMORY_MAX,
+  };
+  if (options?.stateDir === null) {
+    // Memory-only for unit tests.
+    return createClaimableDedupe(base);
+  }
+  const stateDir = options?.stateDir ?? resolveStateDir();
+  return createClaimableDedupe({
+    ...base,
+    fileMaxEntries: WEIXIN_INBOUND_DEDUPE_FILE_MAX,
+    resolveFilePath: (namespace) =>
+      path.join(
+        stateDir,
+        "openclaw-weixin",
+        "replay-dedupe",
+        `${sanitizeSegment(namespace)}.json`,
+      ),
+    onDiskError: (error) => {
+      logger.warn(
+        `[weixin] inbound replay-dedupe disk error: ${error instanceof Error ? error.message : String(error)}`,
+      );
+    },
+  });
+}
+
+let inboundDedupe = createWeixinInboundDedupe();
 
 function extractTextForFallback(itemList?: MessageItem[]): string {
   if (!itemList?.length) return "";
@@ -61,36 +104,53 @@ export function buildWeixinInboundDedupeKey(
   return `weixin:v1:${accountId}:${from}:body:${digest}`;
 }
 
-function pruneExpired(now: number): void {
-  for (const [key, at] of seenAt) {
-    if (now - at > WEIXIN_INBOUND_DEDUPE_TTL_MS) seenAt.delete(key);
-  }
-  if (seenAt.size <= WEIXIN_INBOUND_DEDUPE_MAX_ENTRIES) return;
-  // Hard cap: drop oldest half when overflowing.
-  const entries = [...seenAt.entries()].sort((a, b) => a[1] - b[1]);
-  const drop = Math.ceil(entries.length / 2);
-  for (let i = 0; i < drop; i++) {
-    seenAt.delete(entries[i]![0]);
-  }
-}
+export type WeixinInboundDedupeOptions = {
+  /** Account-scoped disk namespace (file shard). */
+  namespace?: string;
+  now?: number;
+};
 
 /**
  * Claim a logical inbound message for processing.
- * @returns true if this is the first claim (process it); false if a duplicate within TTL.
+ * @returns true if this is the first claim (process it); false if duplicate/in-flight.
  */
-export function claimWeixinInboundMessage(key: string, now = Date.now()): boolean {
-  pruneExpired(now);
-  const prev = seenAt.get(key);
-  if (prev != null && now - prev <= WEIXIN_INBOUND_DEDUPE_TTL_MS) {
-    return false;
-  }
-  seenAt.set(key, now);
-  return true;
+export async function claimWeixinInboundMessage(
+  key: string,
+  options?: WeixinInboundDedupeOptions,
+): Promise<boolean> {
+  const result = await inboundDedupe.claim(key, {
+    namespace: options?.namespace,
+    now: options?.now,
+  });
+  return result.kind === "claimed";
 }
 
-/** Test helper — clears the in-memory cache. */
+/** Persist the claim after successful handling (survives restart for TTL). */
+export async function commitWeixinInboundMessage(
+  key: string,
+  options?: WeixinInboundDedupeOptions,
+): Promise<void> {
+  await inboundDedupe.commit(key, {
+    namespace: options?.namespace,
+    now: options?.now,
+  });
+}
+
+/** Release a held claim so a later delivery can retry after a thrown failure. */
+export function releaseWeixinInboundMessage(
+  key: string,
+  options?: WeixinInboundDedupeOptions & { error?: unknown },
+): void {
+  inboundDedupe.release(key, {
+    namespace: options?.namespace,
+    error: options?.error,
+  });
+}
+
+/** Test helper — switch to memory-only guard and clear. */
 export function resetWeixinInboundDedupeForTests(): void {
-  seenAt.clear();
+  inboundDedupe.clearMemory();
+  inboundDedupe = createWeixinInboundDedupe({ stateDir: null });
 }
 
 export function logWeixinInboundDuplicate(params: {

--- a/src/messaging/inbound-dedupe.ts
+++ b/src/messaging/inbound-dedupe.ts
@@ -4,10 +4,15 @@ import type { MessageItem, WeixinMessage } from "../api/types.js";
 import { MessageItemType } from "../api/types.js";
 import { logger } from "../util/logger.js";
 
-/** Drop short-window getUpdates replays (~1s typical); keep a few minutes for retries. */
+/**
+ * Replay-dedupe TTL for getUpdates at-least-once delivery (~1s typical spacing).
+ * Not a content-dedupe window: a new user send with a new message_id is always claimed.
+ * In-memory Map — single process only; multi-instance gateways need a shared store (out of scope).
+ */
 export const WEIXIN_INBOUND_DEDUPE_TTL_MS = 5 * 60 * 1000;
 const WEIXIN_INBOUND_DEDUPE_MAX_ENTRIES = 20_000;
 
+/** Process-local claim store (single-instance deploy). */
 const seenAt = new Map<string, number>();
 
 function extractTextForFallback(itemList?: MessageItem[]): string {

--- a/src/messaging/inbound.test.ts
+++ b/src/messaging/inbound.test.ts
@@ -14,12 +14,18 @@ vi.mock("../util/logger.js", () => ({
   },
 }));
 
-// Mock crypto.randomBytes for deterministic MessageSid
-vi.mock("node:crypto", () => ({
-  default: {
+// Mock crypto.randomBytes for deterministic MessageSid; keep createHash real for stable sid fallback
+vi.mock("node:crypto", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("node:crypto")>();
+  return {
+    ...actual,
+    default: {
+      ...actual,
+      randomBytes: vi.fn(() => Buffer.from("deadbeef", "hex")),
+    },
     randomBytes: vi.fn(() => Buffer.from("deadbeef", "hex")),
-  },
-}));
+  };
+});
 
 describe("isMediaItem", () => {
   it("returns true for IMAGE type", () => {
@@ -71,8 +77,14 @@ describe("weixinMessageToMsgContext", () => {
     expect(ctx.Provider).toBe("openclaw-weixin");
     expect(ctx.ChatType).toBe("direct");
     expect(ctx.context_token).toBe("ctx-token-abc");
-    expect(ctx.MessageSid).toMatch(/^openclaw-weixin:\d+-[0-9a-f]+$/);
+    // Stable sid from body fingerprint when transport message_id/seq/client_id absent
+    expect(ctx.MessageSid).toMatch(/^weixin:v1:account1:user123:body:[0-9a-f]{16}$/);
     expect(ctx.Timestamp).toBe(1700000000000);
+  });
+
+  it("uses transport message_id for MessageSid when present", () => {
+    const ctx = weixinMessageToMsgContext({ ...baseMsg, message_id: 99 }, "account1");
+    expect(ctx.MessageSid).toBe("weixin:v1:account1:user123:mid:99");
   });
 
   it("handles missing from_user_id", () => {

--- a/src/messaging/inbound.ts
+++ b/src/messaging/inbound.ts
@@ -6,6 +6,7 @@ import { generateId } from "../util/random.js";
 import type { WeixinMessage, MessageItem } from "../api/types.js";
 import { MessageItemType } from "../api/types.js";
 import { resolveStateDir } from "../storage/state-dir.js";
+import { buildWeixinInboundDedupeKey } from "./inbound-dedupe.js";
 
 // ---------------------------------------------------------------------------
 // Context token store (in-process cache + disk persistence)
@@ -131,7 +132,10 @@ export function findAccountIdsByContextToken(
 // Message ID generation
 // ---------------------------------------------------------------------------
 
-function generateMessageSid(): string {
+function generateMessageSid(msg: WeixinMessage, accountId: string): string {
+  // Prefer stable transport identity so transcripts/core can correlate deliveries.
+  const stable = buildWeixinInboundDedupeKey(accountId, msg);
+  if (stable) return stable;
   return generateId("openclaw-weixin");
 }
 
@@ -230,7 +234,7 @@ export function weixinMessageToMsgContext(
     AccountId: accountId,
     OriginatingChannel: "openclaw-weixin",
     OriginatingTo: from_user_id,
-    MessageSid: generateMessageSid(),
+    MessageSid: generateMessageSid(msg, accountId),
     Timestamp: msg.create_time_ms,
     Provider: "openclaw-weixin",
     ChatType: "direct",

--- a/src/messaging/process-message.ts
+++ b/src/messaging/process-message.ts
@@ -33,7 +33,9 @@ import type { WeixinInboundMediaOpts } from "./inbound.js";
 import {
   buildWeixinInboundDedupeKey,
   claimWeixinInboundMessage,
+  commitWeixinInboundMessage,
   logWeixinInboundDuplicate,
+  releaseWeixinInboundMessage,
 } from "./inbound-dedupe.js";
 import { sendWeixinMediaFile } from "./send-media.js";
 import { StreamingMarkdownFilter } from "./markdown-filter.js";
@@ -83,19 +85,53 @@ export async function processOneMessage(
     return;
   }
 
-  // getUpdates is at-least-once; drop short-window replays before any side effects.
+  // getUpdates is at-least-once; claim before any side effects (disk tombstone on commit).
   const dedupeKey = buildWeixinInboundDedupeKey(deps.accountId, full);
-  if (dedupeKey && !claimWeixinInboundMessage(dedupeKey)) {
-    logWeixinInboundDuplicate({
-      accountId: deps.accountId,
-      key: dedupeKey,
-      messageId: full.message_id,
-      seq: full.seq,
-      from: full.from_user_id,
+  let heldDedupeKey: string | null = null;
+  if (dedupeKey) {
+    const claimed = await claimWeixinInboundMessage(dedupeKey, {
+      namespace: deps.accountId,
     });
-    return;
+    if (!claimed) {
+      logWeixinInboundDuplicate({
+        accountId: deps.accountId,
+        key: dedupeKey,
+        messageId: full.message_id,
+        seq: full.seq,
+        from: full.from_user_id,
+      });
+      return;
+    }
+    heldDedupeKey = dedupeKey;
   }
 
+  let dedupeFailed = false;
+  try {
+    await processOneMessageBody(full, deps);
+  } catch (error) {
+    dedupeFailed = true;
+    if (heldDedupeKey) {
+      releaseWeixinInboundMessage(heldDedupeKey, {
+        namespace: deps.accountId,
+        error,
+      });
+      heldDedupeKey = null;
+    }
+    throw error;
+  } finally {
+    if (heldDedupeKey && !dedupeFailed) {
+      await commitWeixinInboundMessage(heldDedupeKey, {
+        namespace: deps.accountId,
+      });
+    }
+  }
+}
+
+/** Inbound handling after replay-dedupe claim (slash / media / AI dispatch). */
+async function processOneMessageBody(
+  full: WeixinMessage,
+  deps: ProcessMessageDeps,
+): Promise<void> {
   const receivedAt = Date.now();
   const debug = isDebugMode(deps.accountId);
   const debugTrace: string[] = [];

--- a/src/messaging/process-message.ts
+++ b/src/messaging/process-message.ts
@@ -30,6 +30,11 @@ import {
   isMediaItem,
 } from "./inbound.js";
 import type { WeixinInboundMediaOpts } from "./inbound.js";
+import {
+  buildWeixinInboundDedupeKey,
+  claimWeixinInboundMessage,
+  logWeixinInboundDuplicate,
+} from "./inbound-dedupe.js";
 import { sendWeixinMediaFile } from "./send-media.js";
 import { StreamingMarkdownFilter } from "./markdown-filter.js";
 import { sendMessageWeixin } from "./send.js";
@@ -75,6 +80,19 @@ export async function processOneMessage(
       `processOneMessage: channelRuntime is undefined, skipping message from=${full.from_user_id}`,
     );
     deps.errLog("processOneMessage: channelRuntime is undefined, skip");
+    return;
+  }
+
+  // getUpdates is at-least-once; drop short-window replays before any side effects.
+  const dedupeKey = buildWeixinInboundDedupeKey(deps.accountId, full);
+  if (dedupeKey && !claimWeixinInboundMessage(dedupeKey)) {
+    logWeixinInboundDuplicate({
+      accountId: deps.accountId,
+      key: dedupeKey,
+      messageId: full.message_id,
+      seq: full.seq,
+      from: full.from_user_id,
+    });
     return;
   }
 


### PR DESCRIPTION
## Summary
- Claim a stable inbound key (`message_id` → `client_id` → `seq` → body fingerprint) at the top of `processOneMessage` via OpenClaw `createClaimableDedupe`, then **commit a disk tombstone** under `$OPENCLAW_STATE_DIR/openclaw-weixin/replay-dedupe/` so at-least-once `getUpdates` deliveries do not run the AI pipeline twice.
- Covers ~1s iLink replays **and** longer redeliveries (e.g. 30–50 min after a stuck long turn), including **across process restart**.
- Derive stable `MessageSid` from the same key when transport ids are present.
- Tests for key selection, claim/commit/TTL/release; CHANGELOG (EN/ZH).

Fixes https://github.com/Tencent/openclaw-weixin/issues/239  
Related: https://github.com/openclaw/openclaw/issues/116723

## Scope / deploy assumption
- **24h replay-dedupe / tombstone window** — same transport id / claim key. Not a content-dedupe window: a user intentionally re-sending the same text with a **new** `message_id` is processed.
- Disk-backed claim survives restart (single host / shared `OPENCLAW_STATE_DIR`). **Multi-replica gateways without shared state** still need a shared store or full channel ingress drain — out of scope here; this matches the transitional `createClaimableDedupe` pattern used by other channels (Discord / Mattermost / Nextcloud Talk / Feishu).

## `message_id` on the wire
iLink `GetUpdatesResp.msgs[]` items are `WeixinMessage`; README documents `message_id` as the unique message id. Production debug already logs `msgId` / `seq`.

```json
{
  "seq": 1234567890,
  "message_id": 9876543210,
  "from_user_id": "<redacted>",
  "to_user_id": "<redacted>",
  "create_time_ms": 1720000000000,
  "item_list": [{ "type": 1, "text_item": { "text": "<redacted>" } }],
  "context_token": "<redacted>"
}
```

## Test plan
- [x] `npx vitest run src/messaging/inbound-dedupe.test.ts src/messaging/inbound.test.ts`
- [x] `npx tsc --noEmit`
- [ ] Maintainer: smoke personal WeChat — send one text, confirm single agent turn / single reply
- [ ] Long-turn / late redelivery: same `message_id` within 24h is dropped; intentional re-send (new id) still processes
- [ ] Restart gateway and confirm tombstone file under `~/.openclaw/openclaw-weixin/replay-dedupe/` still suppresses replay