### PR TITLE
fix(weixin): refuse to send when contextToken is missing (avoid silent-drop)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,148 +1,260 @@
-# Changelog
+# 变更日志
 
-[简体中文](CHANGELOG.zh_CN.md)
+[English](CHANGELOG_EN.md)
 
-This project follows the [Keep a Changelog](https://keepachangelog.com/) format.
+本项目遵循 [Keep a Changelog](https://keepachangelog.com/) 格式。
+
+## [未发布]
+
+### 修复
+
+- **缺 contextToken 时拒绝发送（消除静默丢弃）：** 5 个发送入口
+  （`sendMessageWeixin` / `sendMessageItemWeixin` / `sendImageMessageWeixin` /
+  `sendVideoMessageWeixin` / `sendFileMessageWeixin`）在 `contextToken` 缺失时
+  由原先 `logger.warn` 后继续发送改为直接抛出错误，避免 iLink 后端返回空体导致
+  消息被静默丢弃、而调用方却拿到「假成功」（`messageId`）。错误与日志中不再出现
+  明文接收方 ID，改用 `redactToken` 脱敏（见 Tencent/openclaw-weixin#247）。
+
+## [3.1.0] - 2026-08-10
+
+### 修复
+
+- **OpenClaw SDK 入口兼容：** `createTypingCallbacks` 改从
+  `openclaw/plugin-sdk/channel-message` 导入，同时兼容仍提供旧入口的最低宿主和已经移除
+  `channel-runtime` 的新版宿主；CI 针对两类实际 SDK 构建并导入该边界，且执行无 mock
+  插件注册冒烟。
+- **context token 用户 ID 大小写规范化（发送 ret=-3）：** context token 的账号级内存键和
+  持久化键统一对用户 ID 做小写规范化；getUpdates 返回混合大小写 ID、OpenClaw 会话目标
+  为小写或重启恢复旧格式文件时，仍能命中正确 token
+  （见 Tencent/openclaw-weixin#243）。
+- **QR 登录保留稳定 `--account` 别名（逻辑映射）：** `channels login --account <alias>`
+  成功后凭证与状态仍落在服务端 `ilink_bot_id`（primary hash）下，并写入一对一
+  `alias → hash` 映射供 bindings / 出站解析；`listAccountIds` / monitor 只使用
+  primary；`config.isEnabled` 对别名返回 false，避免宿主 `start(alias)` 建 task
+  后触发重启循环。宿主 `default` 哨兵不会变成别名；`alreadyConnected` 在不歧义时
+  只登记映射，对已有 primary hash 重登为 no-op；拒绝与其它 bot 冲突的别名凭证，
+  不搬迁 sync/context/allow-list；索引原子写入，失败时保留原索引。
+
+## [3.0.2] - 2026-08-05
+
+### 变更
+
+- **入站媒体按 Agent 隔离：** 图片、视频、文件和语音现在按已路由的 Agent 存入
+  `weixin/<agentId>/inbound`，避免多 Agent 部署中的媒体文件混放及跨 Agent
+  访问；无法解析 Agent 时继续使用兼容旧版本的 `inbound` 路径。
+
+### 修复
+
+- **入站 getUpdates 双投递：** ordinary / approval 两条 admission 车道在处理前通过
+  OpenClaw `createClaimableDedupe`（账号隔离的 `resolveFilePath`，落在
+  `openclaw-weixin/replay-dedupe/`，兼容最低宿主 `2026.6.1`）认领稳定去重键
+  （`message_id` → `client_id` → `seq` → 正文指纹），成功后写入 24 小时墓碑，
+  避免 iLink 长轮询至少一次投递（约 1 秒重放）以及长任务卡住后的更长窗口重投
+  把同一条消息跑两遍 AI，并在进程重启后仍生效。失败与 abort 会 release 以便
+  重试。进行中的重放会立刻释放 admission 车道，在车道外观察持有者，仅在
+  release 时重新入队，避免挡住后续不同消息。认领成功后的每一步都在 claim
+  生命周期内。Fallback 优先用 item `msg_id` 摘要，绝不只按发送者建键。重复
+  投递日志只记录非敏感的 identity 种类。该窗口是**重放去重 / 墓碑窗口**，不
+  会吞掉用户故意再发且带有新 `message_id` 的消息。存在传输层 id 时
+  `MessageSid` 使用同一稳定键。移植自
+  [Tencent/openclaw-weixin#240](https://github.com/Tencent/openclaw-weixin/pull/240)；
+  跟踪
+  [NewFuture/openclaw-weixin#36](https://github.com/NewFuture/openclaw-weixin/issues/36)。
+
+## [3.0.1] - 2026-08-02
+
+### 变更
+
+- 将 npm 发布绑定到受保护的 `npm-publish` environment；自动检查全部通过后需由
+  仓库管理员审批，且 OIDC 发布权限仅授予审批后的发布 job。
+- npmjs 发布成功后由同一工作流同步发布 GitHub Packages 镜像
+  `@newfuture/openclaw-weixin`，再创建使用中英文变更日志说明的 GitHub Release；
+  重试时会分别跳过已存在的包版本并补齐缺失目标；包括 registry 为空的情况，前一
+  仓库版本尚未完成镜像时不会发布后续 GitHub Packages 版本。
+- 将最低支持的 OpenClaw 宿主扩展至 `2026.6.1`，保留 `2026.7.1` 作为常规开发
+  基线，并增加最低宿主版本的完整 CI 构建与测试。
+
+## [3.0.0] - 2026-07-31
+
+### 新增
+
+- exec 审批提示现在会分别展示便于复制的 `/approve` 代码块：转发提示会按 OpenClaw
+  允许的决策附加各个短 ID 操作，直接提示则会将 `Other options` 下的每条命令拆成
+  独立代码块。
+
+### 变更
+
+- 将社区 npm 包与插件版本更新至 `3.0.0`，作为统一使用
+  `openclaw-weixin` 单一标识后的首个版本。
+- 将仓库、npm 包、插件和 channel 名称统一为 `openclaw-weixin`，并简化为仅发布
+  一个包。
+- 将 MIT 许可证正文统一为标准格式，并随包发布说明性 `NOTICE`，保留腾讯上游
+  署名及社区修改声明。
+- 增加发布元数据门禁，并在 `main` CI 全部通过后幂等协调发布标签、npm 状态及
+  发布任务，将标签固定在版本转换提交并按版本顺序触发对应发布。
+- 将中文设为默认 README，将英文版移至 `README_EN.md`，并保留
+  `README.zh_CN.md` 作为兼容入口。
+- 将最低支持的 OpenClaw 宿主提升至 `2026.7.1`，并使运行时检查、包元数据、
+  开发环境及 CI 的 Node.js 最低版本与该版本保持一致。
+- 将插件安装与腾讯官方包原位替换统一为同一条 `--force` 命令，并单独说明账号
+  接入、重载验证及 Agent 安装流程；详细用法和协议参考移至随包发布的 `docs/`
+  目录。
+
+### 安全
+
+- 将存在漏洞的开发期传递依赖覆盖为已修复版本，并在 CI 与 npm 发布流程中
+  增加中危及以上依赖审计门禁。
+
+## [2.4.6] - 2026-07-23
+
+### 变更
+
+- 基于腾讯 `@tencent-weixin/openclaw-weixin` 准备首个社区维护的未加 scope
+  npm 发行包 `openclaw-weixin`。
+- 保留内部 `openclaw-weixin` 插件/channel ID、配置键与状态目录，支持原位
+  切换。
+- 增加社区仓库元数据、包内容检查和 npm Trusted Publishing 工作流。
+- 将运行时兼容检查与文档统一为 OpenClaw `>=2026.5.12`、Node.js `>=22`。
 
 ## [2.4.5] - 2026-06-22
 
-### Added
+### 新增
 
-- **`classifyFetchError` — network error classification:** New `classifyFetchError` utility in `src/api/api.ts` classifies fetch-level errors into `dns` / `tcp` / `tls` / `timeout` / `unknown`. `apiGetFetch` and `apiPostFetch` now log structured error details (type, description, code) on failure, making network troubleshooting significantly easier. Includes full test coverage for ENOTFOUND, ECONNREFUSED, ETIMEDOUT, SSL/TLS, AbortError, and more.
-- **`sendMessage` response validation:** `sendMessage` now parses the server response (`SendMessageResp` with `ret` / `errmsg`) and throws on non-zero `ret`, preventing silent delivery failures.
+- **`classifyFetchError` — 网络错误分类：** `src/api/api.ts` 新增 `classifyFetchError` 工具函数，将 fetch 级错误分类为 `dns` / `tcp` / `tls` / `timeout` / `unknown`。`apiGetFetch` 与 `apiPostFetch` 在失败时输出结构化日志（type, description, code），便于排查网络问题。覆盖 ENOTFOUND、ECONNREFUSED、ETIMEDOUT、SSL/TLS、AbortError 等场景的完整测试。
+- **`sendMessage` 返回值校验：** `sendMessage` 现在解析服务端返回的 `SendMessageResp`（`ret` / `errmsg`），`ret` 非零时抛错，避免消息发送静默失败。
 
-### Changed
+### 变更
 
-- **`SESSION_EXPIRED_ERRCODE` → `STALE_TOKEN_ERRCODE`:** Renamed in `src/api/session-guard.ts` to more accurately describe the token-stale condition (the error code -14 indicates a stale/expired token, not a session expiry). All references in `monitor.ts` and tests updated.
-- **Error logging improvements:**
-  - `getUpdates` errors in `monitor.ts` now include `classifyFetchError` classification (type, description, code).
-  - Removed duplicate `errLog` lines in `monitor.ts`; only `aLog.error` remains.
-  - CDN upload failure logs (`cdn-upload.ts`) now include redacted URL and error cause.
-  - `downloadRemoteImageToTemp` (`upload.ts`) now logs detailed fetch network errors with cause.
-  - API GET/POST fetch failures (`api.ts`) now log redacted URL, timeout, and error classification.
-- **Minimum host version bumped:** `peerDependencies.openclaw` and `install.minHostVersion` raised from `>=2026.3.22` to `>=2026.5.12`.
+- **`SESSION_EXPIRED_ERRCODE` → `STALE_TOKEN_ERRCODE`：** 在 `src/api/session-guard.ts` 中重命名，更准确地描述 token 过期（-14 表示 token 失效，而非 session 过期）。`monitor.ts` 与测试中所有引用同步更新。
+- **错误日志改进：**
+  - `monitor.ts` 中 `getUpdates` 的错误日志使用 `classifyFetchError` 输出分类信息（type, description, code）。
+  - `monitor.ts` 移除重复的 `errLog` 日志行，仅保留 `aLog.error`。
+  - CDN 上传失败日志（`cdn-upload.ts`）增加脱敏 URL 和错误 cause 信息。
+  - `downloadRemoteImageToTemp`（`upload.ts`）增加 fetch 网络错误详情日志。
+  - API GET/POST fetch 失败日志（`api.ts`）增加脱敏 URL、超时设置及错误分类信息。
+- **最低宿主版本升级：** `peerDependencies.openclaw` 和 `install.minHostVersion` 从 `>=2026.3.22` 升至 `>=2026.5.12`。
 
-### Added (Dev/Engineering)
+### 新增（开发/工程）
 
-- **`outbound-hooks.test.ts`:** New test file covering `applyWeixinMessageSendingHook` (no hooks, content modification, cancellation, error recovery) and `emitWeixinMessageSent` (no hooks, success, failure with fire-and-forget) scenarios.
+- **`outbound-hooks.test.ts`：** 新增测试文件，覆盖 `applyWeixinMessageSendingHook`（无 hook、内容修改、取消、错误容错）和 `emitWeixinMessageSent`（无 hook、成功、失败走 fire-and-forget）各场景。
 
-### Fixed
+### 修复
 
-- **`pairing.test.ts` mock path:** `vi.mock` target corrected from `"openclaw/plugin-sdk"` to `"openclaw/plugin-sdk/infra-runtime"`.
-- **`api.test.ts` sendMessage mock response:** Success test case mock now returns `"{}"` instead of `""`, matching the updated `sendMessage` logic that parses the response body.
+- **`pairing.test.ts` mock 路径：** `vi.mock` 目标从 `"openclaw/plugin-sdk"` 修正为 `"openclaw/plugin-sdk/infra-runtime"`。
+- **`api.test.ts` sendMessage 测试 mock：** 成功用例的 mock 返回值从 `""` 改为 `"{}"`，与 `sendMessage` 新增的响应解析逻辑一致。
 
 ## [2.4.4] - 2026-05-22
 
-### Added
+### 新增
 
-- **Tool-call progress messages:** `WeixinReplyProgressSender` sends `TOOL_CALL_START` / `TOOL_CALL_RESULT` progress messages when the model executes tools. Configurable via the `replyProgressMessages` channel option (default: `true`).
-- **Abort signal support for in-flight requests:** `apiPostFetch` / `getUpdates` now accept an external `AbortSignal`. When the gateway stops or hot-reloads a channel, the in-flight long-poll is cancelled immediately instead of waiting for the server-side timeout.
+- **工具调用进度消息：** 模型执行 tool 时，发送 `TOOL_CALL_START` / `TOOL_CALL_RESULT` 进度消息，可通过 `replyProgressMessages` 开关控制（默认开启）。
+- **请求中断信号支持：** `apiPostFetch` / `getUpdates` 现在接受外部的 `AbortSignal`。当网关停止或热重载频道时，正在进行的 long-poll 请求会被立即取消，无需等待服务端超时。
 
 ## [2.4.3] - 2026-05-08
 
-### Fixed
+### 修复
 
-- **`iLink-App-Id` / `iLink-App-ClientVersion` headers were empty / `0` in production.** `readPackageJson` resolved `package.json` via a fixed `../../` from `import.meta.url`, but the TypeScript build (with `index.ts` plus `src/**/*.ts` in `tsconfig.include`) emits `dist/src/api/api.js` (extra `src/` segment), so the resolved path landed on the non-existent `dist/package.json` and the catch returned `{}`. Replaced with a walk-up that searches for the plugin's own `package.json` (validated by `name` containing `openclaw-weixin` or by the presence of `ilink_appid`), tolerating both dev (`src/api/`) and built (`dist/src/api/`) layouts. Adds tests in `src/api/api.test.ts` covering the compiled layout, dev layout, nested `node_modules/<dep>/package.json` shadowing, missing manifest, and malformed manifest.
-- **`openclaw channels login` exited non-zero when the bot was already bound to this OpenClaw**, which caused automated installers (e.g. `openclaw-weixin-installer`) to report a misleading "首次连接未完成" message and continue past a successful state. The QR poller now returns `alreadyConnected: true` for the server's `binded_redirect` status, and `auth.login` in `channel.ts` treats it as a successful no-op (no save, no throw) so the CLI exits cleanly.
+- **`iLink-App-Id` / `iLink-App-ClientVersion` 请求头在生产环境为空 / `0`。** `readPackageJson` 用固定的 `../../` 从 `import.meta.url` 推算 `package.json`，但 TypeScript 构建（`tsconfig.include` 同时包含 `index.ts` 和 `src/**/*.ts`）实际产物是 `dist/src/api/api.js`（多出一层 `src/`），导致解析到不存在的 `dist/package.json`，catch 返回 `{}`。改为从当前模块所在目录向上逐级查找，并通过 `name` 包含 `openclaw-weixin` 或存在 `ilink_appid` 字段来确认是本插件自己的 `package.json`，同时兼容开发态（`src/api/`）和发布态（`dist/src/api/`）布局。`src/api/api.test.ts` 新增 5 个用例覆盖编译产物布局、开发布局、途经 `node_modules/<dep>/package.json` 不被误识别、找不到时返回 `{}`、坏 JSON 容错继续向上查找。
+- **`openclaw channels login` 在 "已连接过此 OpenClaw" 场景下被误判为失败。** 服务端返回 `binded_redirect` 时本地凭据其实仍有效，但旧逻辑返回 `connected: false`，`channel.ts` 的 `auth.login` 据此 `throw`，CLI 非零退出，导致 `openclaw-weixin-installer` 等自动化脚本误打印"首次连接未完成"。`WeixinQrWaitResult` 新增 `alreadyConnected` 字段，QR 轮询在 `binded_redirect` 时置为 `true`；`auth.login` 据此仅记录消息、不抛错，CLI 以 0 退出。
 
 ## [2.4.2] - 2026-05-07
 
-### Fixed
+### 修复
 
-- **Node 24 / undici compatibility — `TypeError: fetch failed` on every request.** Drop the manually-set `Content-Length` header from `buildHeaders`. The bundled undici in Node 24 rejects pre-set `Content-Length` with `UND_ERR_INVALID_ARG: invalid content-length header`, breaking all CGI calls. Letting `fetch` compute it from the request body restores network calls on Node 24.
-- **OpenClaw ≥ 2026.5.x — Weixin runtime initialization timeout restart loop.** Replace the module-scope `pluginRuntime` global (and remove `src/runtime.ts` along with it) with the `ctx.channelRuntime` injected by the gateway per call. The previous global was set during plugin registration, but newer hosts inject a per-call runtime surface, so the global was missing/stale at startup and the channel kept timing out and restarting.
+- **Node 24 / undici 兼容性——所有请求 `TypeError: fetch failed`。** 从 `buildHeaders` 中移除手动设置的 `Content-Length`。Node 24 自带的 undici 不允许调用方预设 `Content-Length`，会以 `UND_ERR_INVALID_ARG: invalid content-length header` 拒绝整个请求，导致所有 CGI 调用失败。改由 `fetch` 根据请求体自动计算，恢复在 Node 24 下的网络调用。
+- **OpenClaw ≥ 2026.5.x——微信 runtime 初始化超时无限重启。** 移除模块作用域的 `pluginRuntime` 全局变量（同时删掉 `src/runtime.ts`），改为按调用从网关 ctx 中读取 `ctx.channelRuntime`。原先的全局是在插件注册阶段写入的，但较新宿主改为按调用注入 runtime surface，启动时拿不到/拿到旧值，channel 启动一直超时进而被反复重启。
 
-### Removed
+### 移除
 
-- **Dead scripts and shims:** `scripts/test-full-upload.ts` / `scripts/test-upload-url.ts` debug scripts and the unused legacy `index.ts` re-exports. No behavior change for consumers.
+- **冗余脚本与入口：** 删除调试用的 `scripts/test-full-upload.ts` / `scripts/test-upload-url.ts`，以及遗留的 `index.ts` 转发文件。对调用方无行为变更。
 
 ## [2.4.1] - 2026-05-04
 
-### Added
+### 新增
 
-- **Ship compiled runtime in the npm tarball:** `dist/` is added to `files` and `package.json#openclaw.runtimeExtensions` is set to `["./dist/index.js"]`. The host loads the prebuilt JS entry directly instead of relying on source-only TypeScript at install time, which avoids the `requires compiled runtime output for TypeScript entry index.ts` error on stricter host versions.
-- **`openclaw.plugin.json` channel config:** Declare `channels` and `channelConfigs` in `openclaw.plugin.json` so newer hosts (≥ 2026.4.x) can render the channel selection UI without falling back to `package.json#openclaw`.
+- **npm 包内携带 dist 产物作为 channel 入口：** `package.json` 的 `files` 加入 `dist/`，`openclaw.runtimeExtensions` 设为 `["./dist/index.js"]`；宿主直接加载预编译的 JS 入口，不再依赖装包时的 TypeScript 源码，避免在较严格的宿主版本上出现 `requires compiled runtime output for TypeScript entry index.ts` 错误。
+- **`openclaw.plugin.json` 频道配置：** 在 `openclaw.plugin.json` 中声明 `channels` 与 `channelConfigs`，使较新宿主（≥ 2026.4.x）能直接渲染频道选择 UI，无需回退到 `package.json#openclaw`。
 
 ## [2.3.1] - 2026-04-28
 
-### Added
+### 新增
 
-- **`bot_agent` request field:** Outgoing CGI requests now carry an upstream-app-supplied `bot_agent` (UA-style `name/version (comment)` grammar, multi-product allowed). Configurable per upstream app via channel config and sanitized by `sanitizeBotAgent` in `src/api/api.ts`; falls back to `OpenClaw` when missing or invalid.
-- **`local_token_list` on QR fetch:** `fetchQRCode` now posts the most recent local `bot_token`s (up to 10), enabling the server to recognize already-bound bots and reply with `binded_redirect` instead of issuing a duplicate session.
-- **Pair-code login flow:** Support entering a pair-code (`verify_code`) when the QR scan triggers a server-side challenge; `waitForWeixinLogin` handles `need_verifycode` / `verify_code_blocked` states with a stdin prompt and bounded retries.
-- **`binded_redirect` handling:** New status branch in QR polling that prints `✅ 已连接过此 OpenClaw，无需重复连接。` and returns gracefully when the scanned bot is already bound to this OpenClaw.
-- **Connection status notify (start/stop):** Emit `notifyStart` from `gateway.startAccount` (after the provider is announced) and `notifyStop` from a new `gateway.stopAccount` hook, so the upstream Weixin server can reconcile per-account online state.
+- **`bot_agent` 请求字段：** 上行 CGI 现在携带由上层应用提供的 `bot_agent`（类似 UA 的 `name/version (comment)` 语法，支持多个 product），按上层应用的 channel 配置传入；`src/api/api.ts` 中的 `sanitizeBotAgent` 负责清洗与长度上限，缺失或不合法时回落为 `OpenClaw`。
+- **扫码时上送 `local_token_list`：** `fetchQRCode` 现在带上本地最近 10 个 `bot_token`，让服务端识别"已绑定到本端"的 bot 并下发 `binded_redirect`，避免重复发会话。
+- **配对码登录流程：** 服务端要求二次校验时（`need_verifycode` / `verify_code_blocked`），`waitForWeixinLogin` 通过 stdin 提示用户输入 `verify_code` 并做有限次重试。
+- **`binded_redirect` 处理：** QR 轮询新增分支，输出 `✅ 已连接过此 OpenClaw，无需重复连接。` 并优雅返回。
+- **连接状态通知（start/stop）：** `gateway.startAccount` 在 provider 注册后调用 `notifyStart`，新增的 `gateway.stopAccount` hook 调用 `notifyStop`，便于上游微信服务端对账户在线状态进行对账。
 
-### Changed
+### 变更
 
-- **QR login UX:** Reword the QR/scan prompts and remove the client-side timeout from `fetchQRCode` / `startWeixinLoginWithQr` — only server / stack limits now bound the long-poll.
+- **扫码登录文案：** 调整 QR / 扫码相关的提示文案；同时移除 `fetchQRCode` / `startWeixinLoginWithQr` 的客户端超时，长轮询仅受服务端与网络栈限制。
 
 ## [2.1.10] - 2026-04-24
 
-### Added
+### 新增
 
-- **Connection status notify (start/stop) — initial introduction:** `notifyStart` on account startup and `notifyStop` on shutdown via the new `gateway.stopAccount` hook. (Carried into the 2.3.x line as well.)
+- **连接状态通知（start/stop）首次引入：** 账号启动时发送 `notifyStart`，关闭时通过新的 `gateway.stopAccount` hook 发送 `notifyStop`。该能力在后续 2.3.x 中保留。
 
 ## [2.1.9] - 2026-04-20
 
-### Added
+### 新增
 
-- **Outbound hook support:** Add `message_sending` (pre-send interception/modification) and `message_sent` (post-send notification) hook integration for all outbound paths — `sendText`, `sendMedia`, and the inbound-reply `deliver` in `process-message`. Hook logic is extracted into a shared `src/messaging/outbound-hooks.ts` module.
+- **外发 hook 支持：** 为所有外发路径（`sendText`、`sendMedia`、`process-message` 中的入站回复 `deliver`）接入 `message_sending`（发送前拦截/修改）和 `message_sent`（发送后通知）hook。hook 逻辑抽取至共享模块 `src/messaging/outbound-hooks.ts`。
 
-### Changed
+### 变更
 
-- **Cleanup:** Remove unused `mediaUrl` parameter from `sendWeixinOutbound` signature.
+- **清理：** 移除 `sendWeixinOutbound` 签名中未使用的 `mediaUrl` 参数。
 
 ## [2.1.8] - 2026-04-07
 
-### Changed
+### 变更
 
-- **Markdown filter:** `StreamingMarkdownFilter` now preserves more Markdown constructs in outbound text.
+- **Markdown 过滤器：** `StreamingMarkdownFilter` 放开了更多 Markdown 格式的保留。
 
 ## [2.1.7] - 2026-04-07
 
-### Fixed
+### 修复
 
-- **Plugin registration re-entrance:** Lazy-import `monitorWeixinProvider` inside `startAccount` in `channel.ts` to avoid pulling in the monitor → process-message → command-auth chain at plugin registration time, which could re-enter the plugin/provider registry before the account starts.
-- **Initialization side effect:** Lazy-import `resolveSenderCommandAuthorizationWithRuntime` / `resolveDirectDmAuthorizationOutcome` in `process-message.ts` to prevent `ensureContextWindowCacheLoaded` from being triggered during module initialization, which caused `loadOpenClawPlugins` re-entrance.
+- **插件注册重入：** `channel.ts` 中将 `monitorWeixinProvider` 改为在 `startAccount` 内部懒加载（`await import(...)`），避免插件注册阶段提前拉取 monitor → process-message → command-auth 依赖链，导致 plugin/provider registry 重入。
+- **初始化副作用：** `process-message.ts` 中将 `resolveSenderCommandAuthorizationWithRuntime` / `resolveDirectDmAuthorizationOutcome` 改为懒加载，避免模块初始化时触发宿主的 `ensureContextWindowCacheLoaded` 副作用，进而导致 `loadOpenClawPlugins` 重入。
 
-### Changed
+### 变更
 
-- **Tool-call outbound path:** `sendWeixinOutbound` now applies `StreamingMarkdownFilter` to the outbound text, consistent with the model-output path in `process-message`.
+- **tool-call 外发路径：** `sendWeixinOutbound` 现在对发送文本应用 `StreamingMarkdownFilter`，与 `process-message` 中的 model-output 路径保持一致。
 
 ## [2.1.4] - 2026-04-03
 
-### Changed
+### 变更
 
-- **QR login:** Remove client-side timeout for `get_bot_qrcode`; the request is no longer aborted on a fixed deadline (server / stack limits still apply).
+- **扫码登录：** 移除 `get_bot_qrcode` 的客户端超时，请求不再因固定时限被 abort（仍受服务端与网络栈限制）。
 
 ## [2.1.3] - 2026-04-02
 
-### Added
+### 新增
 
-- **`StreamingMarkdownFilter`** (`src/messaging/markdown-filter.ts`): outbound text no longer runs through whole-string `markdownToPlainText` stripping; a streaming character filter replaces it, so Markdown goes from **effectively unsupported** to **partially supported**.
+- **`StreamingMarkdownFilter`**（`src/messaging/markdown-filter.ts`）：外发文本由原先 `markdownToPlainText` 整段剥离 Markdown，改为流式逐字符过滤；**对 Markdown 从完全不支持变为部分支持**。
 
-### Changed
+### 变更
 
-- **Outbound text path:** `process-message` uses `StreamingMarkdownFilter` (`feed` / `flush`) per deliver chunk instead of `markdownToPlainText`.
+- **外发文本：** `process-message` 在每次 `deliver` 时用 `StreamingMarkdownFilter`（`feed` / `flush`）处理回复，替代 `markdownToPlainText`。
 
-### Removed
+### 移除
 
-- **`markdownToPlainText`** from `src/messaging/send.ts` (and its tests from `send.test.ts`); coverage moves to `markdown-filter.test.ts`.
+- 从 `src/messaging/send.ts` 删除 **`markdownToPlainText`**（相关用例从 `send.test.ts` 迁至 `markdown-filter.test.ts`）。
 
 ## [2.1.2] - 2026-04-02
 
-### Changed
+### 变更
 
-- **Config reload after login:** On each successful Weixin login, bump `channels.openclaw-weixin.channelConfigUpdatedAt` (ISO 8601) in `openclaw.json` so the gateway reloads config from disk, instead of writing an empty `accounts: {}` placeholder.
-- **QR login:** Increase client timeout for `get_bot_qrcode` from 5s to 10s.
-- **Docs:** Uninstall instructions now use `openclaw plugins uninstall @tencent-weixin/openclaw-weixin` (aligned with the plugins CLI).
-- **Logging:** `debug-check` log line no longer includes `stateDir` / `OPENCLAW_STATE_DIR`.
+- **登录后配置刷新：** 每次微信登录成功后，在 `openclaw.json` 中更新 `channels.openclaw-weixin.channelConfigUpdatedAt`（ISO 8601），让网关从磁盘重新加载配置；不再写入空的 `accounts: {}` 占位。
+- **扫码登录：** `get_bot_qrcode` 客户端超时由 5s 调整为 10s。
+- **文档：** 卸载说明改为使用 `openclaw plugins uninstall @tencent-weixin/openclaw-weixin`，与插件 CLI 一致。
+- **日志：** `debug-check` 日志不再输出 `stateDir` / `OPENCLAW_STATE_DIR`。
 
-### Removed
+### 移除
 
-- **`openclaw-weixin` CLI subcommands** (`src/weixin-cli.ts` and registration in `index.ts`). Use the host `openclaw plugins uninstall …` flow instead.
+- **`openclaw-weixin` 子命令**（删除 `src/weixin-cli.ts` 及 `index.ts` 中的注册）。请使用宿主自带的 `openclaw plugins uninstall …` 卸载流程。
 
-### Fixed
+### 修复
 
-- Resolves the **dangerous code pattern** warning when installing the plugin on **OpenClaw 2026.3.31+** (host plugin install / static checks).
+- 解决在 **OpenClaw 2026.3.31 及更新版本**上安装插件时出现的 **dangerous code pattern** 提示（宿主插件安装 / 静态检查）。

--- a/CHANGELOG_EN.md
+++ b/CHANGELOG_EN.md
@@ -1,0 +1,281 @@
+# Changelog
+
+[简体中文](CHANGELOG.md)
+
+This project follows the [Keep a Changelog](https://keepachangelog.com/) format.
+
+## [Unreleased]
+
+### Fixed
+
+- **Refuse to send when `contextToken` is missing (avoid silent-drop):** the 5
+  send entry points (`sendMessageWeixin`, `sendMessageItemWeixin`,
+  `sendImageMessageWeixin`, `sendVideoMessageWeixin`, `sendFileMessageWeixin`)
+  now throw instead of `logger.warn`-and-continue when `contextToken` is absent,
+  preventing iLink from silently dropping the message (empty 200 body) while the
+  caller still receives a fake success (`messageId`). Recipient IDs are no longer
+  logged in plaintext; they are redacted via `redactToken`
+  (see Tencent/openclaw-weixin#247).
+
+## [3.1.0] - 2026-08-10
+
+### Fixed
+
+- **OpenClaw SDK entry compatibility:** `createTypingCallbacks` now imports from
+  `openclaw/plugin-sdk/channel-message`, supporting both the minimum host that
+  still exposes the legacy entry and modern hosts that removed `channel-runtime`.
+  CI builds and imports this boundary and runs an unmocked plugin-registration
+  smoke against both real SDK profiles.
+- **Context-token user ID case normalization (outbound ret=-3):** account-scoped
+  in-memory and persisted context-token keys now lowercase the user ID. Mixed-case
+  IDs from getUpdates, lowercased OpenClaw session targets, and legacy persisted
+  files therefore resolve the same token after restart
+  (see Tencent/openclaw-weixin#243).
+- **Persist stable `--account` aliases on QR login (logical mapping):** after
+  `channels login --account <alias>` succeeds, credentials and state stay under
+  the server `ilink_bot_id` (primary hash) and a 1:1 `alias → hash` map is stored
+  for bindings / outbound resolution. `listAccountIds` / monitors use only the
+  primary; `config.isEnabled` returns false for aliases so host `start(alias)` is
+  rejected before a lifecycle task (no restart loop). The host `default` sentinel
+  is never treated as an alias; `alreadyConnected` only records the mapping when
+  unambiguous and is a no-op for existing primary-hash relogin; conflicting alias
+  credentials are rejected without moving sync/context/allow-list state; the
+  account index is written atomically and left intact if publish fails.
+
+## [3.0.2] - 2026-08-05
+
+### Changed
+
+- **Per-agent inbound media isolation:** images, videos, files, and voice messages
+  are now stored under `weixin/<agentId>/inbound` for the routed agent, preventing
+  mixed media and cross-agent access in multi-agent deployments. Unresolved
+  routes continue to use the legacy-compatible `inbound` path.
+
+### Fixed
+
+- **Inbound getUpdates duplicate delivery:** ordinary and approval admission
+  lanes claim a stable dedupe key (`message_id` → `client_id` → `seq` → body
+  fingerprint) via OpenClaw `createClaimableDedupe` (account-scoped
+  `resolveFilePath` under `openclaw-weixin/replay-dedupe/`, compatible with the
+  minimum host `2026.6.1`) before processing, then commit a 24h tombstone so
+  at-least-once iLink long-poll replays (~1s) and longer redeliveries after
+  stuck long turns do not run the AI pipeline twice — including across process
+  restart. Failures and abort release the claim for retry. In-flight replays
+  release the admission lane immediately, observe the owner out of band, and
+  re-enqueue only if the owner releases — so a distinct follow-up message is
+  not blocked. Claim ownership wraps every step after admission. Fallback keys
+  prefer item `msg_id` digests and never key by sender alone. Duplicate logs
+  record only a non-sensitive identity kind. The window is a **replay-dedupe /
+  tombstone window**, not a content dedupe that swallows intentional re-sends
+  with a new `message_id`. Stable `MessageSid` uses the same key when transport
+  ids are present. Port of
+  [Tencent/openclaw-weixin#240](https://github.com/Tencent/openclaw-weixin/pull/240);
+  tracks [NewFuture/openclaw-weixin#36](https://github.com/NewFuture/openclaw-weixin/issues/36).
+
+## [3.0.1] - 2026-08-02
+
+### Changed
+
+- Bound npm publishing to the protected `npm-publish` environment, requiring a
+  repository administrator's approval after automated validation and granting
+  OIDC publish permission only to the approved job.
+- Made the same workflow mirror each npmjs release to GitHub Packages as
+  `@newfuture/openclaw-weixin`, then create a GitHub Release from the bilingual
+  changelogs; retries skip existing package versions and reconcile missing
+  destinations; publication remains blocked, including when the registry is
+  empty, until the preceding repository release reaches GitHub Packages.
+- Expanded the minimum supported OpenClaw host to `2026.6.1`, retained
+  `2026.7.1` as the normal development baseline, and added a full minimum-host
+  CI build and test.
+
+## [3.0.0] - 2026-07-31
+
+### Added
+
+- Exec approval prompts now expose separate copy-friendly `/approve` code blocks:
+  forwarded prompts append each allowed short-ID action, while direct prompts
+  split each command under `Other options` into its own block.
+
+### Changed
+
+- Set the community package and plugin version to `3.0.0` for the first release
+  after consolidating on the single `openclaw-weixin` identity.
+- Standardized the repository, npm package, plugin, and channel name on
+  `openclaw-weixin`, and simplified releases to publish one package.
+- Standardized the MIT license text and packaged an informational `NOTICE`
+  preserving Tencent's upstream attribution and the community modification
+  notice.
+- Added a release metadata gate and idempotent release reconciliation after
+  successful `main` CI, with immutable transition-commit tagging and ordered npm
+  publication.
+- Made Chinese the primary README and moved the English version to
+  `README_EN.md`, while retaining `README.zh_CN.md` as a compatibility link.
+- Raised the minimum supported OpenClaw host to `2026.7.1` and aligned the
+  runtime guard, package metadata, development environment, and CI Node.js
+  floors with that release.
+- Unified plugin installation and in-place Tencent-package replacement around
+  one `--force` command, with separate account setup, reload verification, and
+  agent guidance; moved detailed usage and protocol reference into the packaged
+  `docs/` directory.
+
+### Security
+
+- Overrode vulnerable transitive development dependencies with patched versions
+  and added a moderate-or-higher dependency audit gate to CI and npm releases.
+
+## [2.4.6] - 2026-07-23
+
+### Changed
+
+- Prepared the first community-maintained npm distribution as the unscoped
+  `openclaw-weixin` package, derived from Tencent's
+  `@tencent-weixin/openclaw-weixin`.
+- Preserved the internal `openclaw-weixin` plugin/channel id, configuration
+  keys, and state paths for in-place migration.
+- Added community repository metadata, package-content checks, and an
+  npm Trusted Publishing workflow.
+- Aligned the runtime compatibility guard and documentation with OpenClaw
+  `>=2026.5.12` and Node.js `>=22`.
+
+## [2.4.5] - 2026-06-22
+
+### Added
+
+- **`classifyFetchError` — network error classification:** New `classifyFetchError` utility in `src/api/api.ts` classifies fetch-level errors into `dns` / `tcp` / `tls` / `timeout` / `unknown`. `apiGetFetch` and `apiPostFetch` now log structured error details (type, description, code) on failure, making network troubleshooting significantly easier. Includes full test coverage for ENOTFOUND, ECONNREFUSED, ETIMEDOUT, SSL/TLS, AbortError, and more.
+- **`sendMessage` response validation:** `sendMessage` now parses the server response (`SendMessageResp` with `ret` / `errmsg`) and throws on non-zero `ret`, preventing silent delivery failures.
+
+### Changed
+
+- **`SESSION_EXPIRED_ERRCODE` → `STALE_TOKEN_ERRCODE`:** Renamed in `src/api/session-guard.ts` to more accurately describe the token-stale condition (the error code -14 indicates a stale/expired token, not a session expiry). All references in `monitor.ts` and tests updated.
+- **Error logging improvements:**
+  - `getUpdates` errors in `monitor.ts` now include `classifyFetchError` classification (type, description, code).
+  - Removed duplicate `errLog` lines in `monitor.ts`; only `aLog.error` remains.
+  - CDN upload failure logs (`cdn-upload.ts`) now include redacted URL and error cause.
+  - `downloadRemoteImageToTemp` (`upload.ts`) now logs detailed fetch network errors with cause.
+  - API GET/POST fetch failures (`api.ts`) now log redacted URL, timeout, and error classification.
+- **Minimum host version bumped:** `peerDependencies.openclaw` and `install.minHostVersion` raised from `>=2026.3.22` to `>=2026.5.12`.
+
+### Added (Dev/Engineering)
+
+- **`outbound-hooks.test.ts`:** New test file covering `applyWeixinMessageSendingHook` (no hooks, content modification, cancellation, error recovery) and `emitWeixinMessageSent` (no hooks, success, failure with fire-and-forget) scenarios.
+
+### Fixed
+
+- **`pairing.test.ts` mock path:** `vi.mock` target corrected from `"openclaw/plugin-sdk"` to `"openclaw/plugin-sdk/infra-runtime"`.
+- **`api.test.ts` sendMessage mock response:** Success test case mock now returns `"{}"` instead of `""`, matching the updated `sendMessage` logic that parses the response body.
+
+## [2.4.4] - 2026-05-22
+
+### Added
+
+- **Tool-call progress messages:** `WeixinReplyProgressSender` sends `TOOL_CALL_START` / `TOOL_CALL_RESULT` progress messages when the model executes tools. Configurable via the `replyProgressMessages` channel option (default: `true`).
+- **Abort signal support for in-flight requests:** `apiPostFetch` / `getUpdates` now accept an external `AbortSignal`. When the gateway stops or hot-reloads a channel, the in-flight long-poll is cancelled immediately instead of waiting for the server-side timeout.
+
+## [2.4.3] - 2026-05-08
+
+### Fixed
+
+- **`iLink-App-Id` / `iLink-App-ClientVersion` headers were empty / `0` in production.** `readPackageJson` resolved `package.json` via a fixed `../../` from `import.meta.url`, but the TypeScript build (with `index.ts` plus `src/**/*.ts` in `tsconfig.include`) emits `dist/src/api/api.js` (extra `src/` segment), so the resolved path landed on the non-existent `dist/package.json` and the catch returned `{}`. Replaced with a walk-up that searches for the plugin's own `package.json` (validated by `name` containing `openclaw-weixin` or by the presence of `ilink_appid`), tolerating both dev (`src/api/`) and built (`dist/src/api/`) layouts. Adds tests in `src/api/api.test.ts` covering the compiled layout, dev layout, nested `node_modules/<dep>/package.json` shadowing, missing manifest, and malformed manifest.
+- **`openclaw channels login` exited non-zero when the bot was already bound to this OpenClaw**, which caused automated installers (e.g. `openclaw-weixin-installer`) to report a misleading "首次连接未完成" message and continue past a successful state. The QR poller now returns `alreadyConnected: true` for the server's `binded_redirect` status, and `auth.login` in `channel.ts` treats it as a successful no-op (no save, no throw) so the CLI exits cleanly.
+
+## [2.4.2] - 2026-05-07
+
+### Fixed
+
+- **Node 24 / undici compatibility — `TypeError: fetch failed` on every request.** Drop the manually-set `Content-Length` header from `buildHeaders`. The bundled undici in Node 24 rejects pre-set `Content-Length` with `UND_ERR_INVALID_ARG: invalid content-length header`, breaking all CGI calls. Letting `fetch` compute it from the request body restores network calls on Node 24.
+- **OpenClaw ≥ 2026.5.x — Weixin runtime initialization timeout restart loop.** Replace the module-scope `pluginRuntime` global (and remove `src/runtime.ts` along with it) with the `ctx.channelRuntime` injected by the gateway per call. The previous global was set during plugin registration, but newer hosts inject a per-call runtime surface, so the global was missing/stale at startup and the channel kept timing out and restarting.
+
+### Removed
+
+- **Dead scripts and shims:** `scripts/test-full-upload.ts` / `scripts/test-upload-url.ts` debug scripts and the unused legacy `index.ts` re-exports. No behavior change for consumers.
+
+## [2.4.1] - 2026-05-04
+
+### Added
+
+- **Ship compiled runtime in the npm tarball:** `dist/` is added to `files` and `package.json#openclaw.runtimeExtensions` is set to `["./dist/index.js"]`. The host loads the prebuilt JS entry directly instead of relying on source-only TypeScript at install time, which avoids the `requires compiled runtime output for TypeScript entry index.ts` error on stricter host versions.
+- **`openclaw.plugin.json` channel config:** Declare `channels` and `channelConfigs` in `openclaw.plugin.json` so newer hosts (≥ 2026.4.x) can render the channel selection UI without falling back to `package.json#openclaw`.
+
+## [2.3.1] - 2026-04-28
+
+### Added
+
+- **`bot_agent` request field:** Outgoing CGI requests now carry an upstream-app-supplied `bot_agent` (UA-style `name/version (comment)` grammar, multi-product allowed). Configurable per upstream app via channel config and sanitized by `sanitizeBotAgent` in `src/api/api.ts`; falls back to `OpenClaw` when missing or invalid.
+- **`local_token_list` on QR fetch:** `fetchQRCode` now posts the most recent local `bot_token`s (up to 10), enabling the server to recognize already-bound bots and reply with `binded_redirect` instead of issuing a duplicate session.
+- **Pair-code login flow:** Support entering a pair-code (`verify_code`) when the QR scan triggers a server-side challenge; `waitForWeixinLogin` handles `need_verifycode` / `verify_code_blocked` states with a stdin prompt and bounded retries.
+- **`binded_redirect` handling:** New status branch in QR polling that prints `✅ 已连接过此 OpenClaw，无需重复连接。` and returns gracefully when the scanned bot is already bound to this OpenClaw.
+- **Connection status notify (start/stop):** Emit `notifyStart` from `gateway.startAccount` (after the provider is announced) and `notifyStop` from a new `gateway.stopAccount` hook, so the upstream Weixin server can reconcile per-account online state.
+
+### Changed
+
+- **QR login UX:** Reword the QR/scan prompts and remove the client-side timeout from `fetchQRCode` / `startWeixinLoginWithQr` — only server / stack limits now bound the long-poll.
+
+## [2.1.10] - 2026-04-24
+
+### Added
+
+- **Connection status notify (start/stop) — initial introduction:** `notifyStart` on account startup and `notifyStop` on shutdown via the new `gateway.stopAccount` hook. (Carried into the 2.3.x line as well.)
+
+## [2.1.9] - 2026-04-20
+
+### Added
+
+- **Outbound hook support:** Add `message_sending` (pre-send interception/modification) and `message_sent` (post-send notification) hook integration for all outbound paths — `sendText`, `sendMedia`, and the inbound-reply `deliver` in `process-message`. Hook logic is extracted into a shared `src/messaging/outbound-hooks.ts` module.
+
+### Changed
+
+- **Cleanup:** Remove unused `mediaUrl` parameter from `sendWeixinOutbound` signature.
+
+## [2.1.8] - 2026-04-07
+
+### Changed
+
+- **Markdown filter:** `StreamingMarkdownFilter` now preserves more Markdown constructs in outbound text.
+
+## [2.1.7] - 2026-04-07
+
+### Fixed
+
+- **Plugin registration re-entrance:** Lazy-import `monitorWeixinProvider` inside `startAccount` in `channel.ts` to avoid pulling in the monitor → process-message → command-auth chain at plugin registration time, which could re-enter the plugin/provider registry before the account starts.
+- **Initialization side effect:** Lazy-import `resolveSenderCommandAuthorizationWithRuntime` / `resolveDirectDmAuthorizationOutcome` in `process-message.ts` to prevent `ensureContextWindowCacheLoaded` from being triggered during module initialization, which caused `loadOpenClawPlugins` re-entrance.
+
+### Changed
+
+- **Tool-call outbound path:** `sendWeixinOutbound` now applies `StreamingMarkdownFilter` to the outbound text, consistent with the model-output path in `process-message`.
+
+## [2.1.4] - 2026-04-03
+
+### Changed
+
+- **QR login:** Remove client-side timeout for `get_bot_qrcode`; the request is no longer aborted on a fixed deadline (server / stack limits still apply).
+
+## [2.1.3] - 2026-04-02
+
+### Added
+
+- **`StreamingMarkdownFilter`** (`src/messaging/markdown-filter.ts`): outbound text no longer runs through whole-string `markdownToPlainText` stripping; a streaming character filter replaces it, so Markdown goes from **effectively unsupported** to **partially supported**.
+
+### Changed
+
+- **Outbound text path:** `process-message` uses `StreamingMarkdownFilter` (`feed` / `flush`) per deliver chunk instead of `markdownToPlainText`.
+
+### Removed
+
+- **`markdownToPlainText`** from `src/messaging/send.ts` (and its tests from `send.test.ts`); coverage moves to `markdown-filter.test.ts`.
+
+## [2.1.2] - 2026-04-02
+
+### Changed
+
+- **Config reload after login:** On each successful Weixin login, bump `channels.openclaw-weixin.channelConfigUpdatedAt` (ISO 8601) in `openclaw.json` so the gateway reloads config from disk, instead of writing an empty `accounts: {}` placeholder.
+- **QR login:** Increase client timeout for `get_bot_qrcode` from 5s to 10s.
+- **Docs:** Uninstall instructions now use `openclaw plugins uninstall @tencent-weixin/openclaw-weixin` (aligned with the plugins CLI).
+- **Logging:** `debug-check` log line no longer includes `stateDir` / `OPENCLAW_STATE_DIR`.
+
+### Removed
+
+- **`openclaw-weixin` CLI subcommands** (`src/weixin-cli.ts` and registration in `index.ts`). Use the host `openclaw plugins uninstall …` flow instead.
+
+### Fixed
+
+- Resolves the **dangerous code pattern** warning when installing the plugin on **OpenClaw 2026.3.31+** (host plugin install / static checks).

--- a/src/messaging/send.test.ts
+++ b/src/messaging/send.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("../util/logger.js", () => ({
   logger: {
@@ -24,38 +24,44 @@ vi.mock("node:crypto", () => ({
 }));
 
 vi.mock("openclaw/plugin-sdk", () => ({
-  stripMarkdown: (text: string) => text
-    .replace(/\*\*([^*]+)\*\*/g, "$1")
-    .replace(/\*([^*]+)\*/g, "$1")
-    .replace(/_([^_]+)_/g, "$1")
-    .replace(/~~([^~]+)~~/g, "$1")
-    .replace(/^#{1,6}\s+/gm, "")
-    .replace(/^[*-]\s+/gm, "")
-    .replace(/^\d+\.\s+/gm, ""),
+  stripMarkdown: (text: string) =>
+    text
+      .replace(/\*\*([^*]+)\*\*/g, "$1")
+      .replace(/\*([^*]+)\*/g, "$1")
+      .replace(/_([^_]+)_/g, "$1")
+      .replace(/~~([^~]+)~~/g, "$1")
+      .replace(/^#{1,6}\s+/gm, "")
+      .replace(/^[*-]\s+/gm, "")
+      .replace(/^\d+\.\s+/gm, ""),
 }));
 
-import {
-  sendMessageWeixin,
-  sendMessageItemWeixin,
-  sendImageMessageWeixin,
-  sendVideoMessageWeixin,
-  sendFileMessageWeixin,
-} from "./send.js";
 import { MessageItemType } from "../api/types.js";
 import type { UploadedFileInfo } from "../cdn/upload.js";
+import {
+  sendFileMessageWeixin,
+  sendImageMessageWeixin,
+  sendMessageItemWeixin,
+  sendMessageWeixin,
+  sendVideoMessageWeixin,
+} from "./send.js";
 
 beforeEach(() => {
-  vi.clearAllMocks();
+  // resetAllMocks (not clearAllMocks) so queued mock*Once values from a
+  // previous test that never called the mock don't leak into the next test.
+  vi.resetAllMocks();
   vi.spyOn(Date, "now").mockReturnValue(1700000000000);
 });
 
 describe("sendMessageWeixin", () => {
-  it("sends without contextToken (no throw)", async () => {
-    mockSendMessageApi.mockResolvedValueOnce(undefined);
-    const result = await sendMessageWeixin({
-      to: "user1", text: "hello", opts: { baseUrl: "https://api.com" },
-    });
-    expect(result.messageId).toBeDefined();
+  it("refuses to send without contextToken (throws)", async () => {
+    await expect(
+      sendMessageWeixin({
+        to: "user1",
+        text: "hello",
+        opts: { baseUrl: "https://api.com" },
+      }),
+    ).rejects.toThrow(/contextToken missing/);
+    expect(mockSendMessageApi).not.toHaveBeenCalled();
   });
 
   it("sends text message successfully", async () => {
@@ -149,32 +155,24 @@ function makeUploadedFileInfo(overrides?: Partial<UploadedFileInfo>): UploadedFi
 }
 
 describe("sendImageMessageWeixin", () => {
-  it("sends without contextToken (no throw)", async () => {
-    mockSendMessageApi.mockResolvedValueOnce(undefined);
-    const result = await sendImageMessageWeixin({
-      to: "u", text: "", uploaded: makeUploadedFileInfo(),
-      opts: { baseUrl: "https://api.com" },
-    });
-    expect(result.messageId).toBeDefined();
+  it("refuses to send without contextToken (throws)", async () => {
+    await expect(
+      sendImageMessageWeixin({
+        to: "u",
+        text: "",
+        uploaded: makeUploadedFileInfo(),
+        opts: { baseUrl: "https://api.com" },
+      }),
+    ).rejects.toThrow(/contextToken missing/);
+    expect(mockSendMessageApi).not.toHaveBeenCalled();
   });
 
-  it("sends image message with thumbnail", async () => {
+  it("sends image caption before the media item", async () => {
     mockSendMessageApi.mockResolvedValue(undefined);
-    const uploaded = makeUploadedFileInfo({
-      imageWidth: 800,
-      imageHeight: 600,
-      thumb: {
-        filekey: "fk",
-        downloadEncryptedQueryParam: "tp",
-        aeskey: "0123456789abcdef0123456789abcdef",
-        fileSize: 200,
-        fileSizeCiphertext: 208,
-        width: 300,
-        height: 225,
-      },
-    });
     const result = await sendImageMessageWeixin({
-      to: "user1", text: "caption", uploaded,
+      to: "user1",
+      text: "caption",
+      uploaded: makeUploadedFileInfo(),
       opts: { baseUrl: "https://api.com", contextToken: "ctx" },
     });
     expect(result.messageId).toBeDefined();
@@ -197,7 +195,9 @@ describe("sendImageMessageWeixin", () => {
   it("sends image message without caption (single call)", async () => {
     mockSendMessageApi.mockResolvedValue(undefined);
     const result = await sendImageMessageWeixin({
-      to: "user1", text: "", uploaded: makeUploadedFileInfo(),
+      to: "user1",
+      text: "",
+      uploaded: makeUploadedFileInfo(),
       opts: { baseUrl: "https://api.com", contextToken: "ctx" },
     });
     expect(result.messageId).toBeDefined();
@@ -208,7 +208,9 @@ describe("sendImageMessageWeixin", () => {
     mockSendMessageApi.mockRejectedValueOnce(new Error("cdn fail"));
     await expect(
       sendImageMessageWeixin({
-        to: "user1", text: "", uploaded: makeUploadedFileInfo(),
+        to: "user1",
+        text: "",
+        uploaded: makeUploadedFileInfo(),
         opts: { baseUrl: "https://api.com", contextToken: "ctx" },
       }),
     ).rejects.toThrow("cdn fail");
@@ -216,63 +218,153 @@ describe("sendImageMessageWeixin", () => {
 });
 
 describe("sendVideoMessageWeixin", () => {
-  it("sends without contextToken (no throw)", async () => {
-    mockSendMessageApi.mockResolvedValueOnce(undefined);
-    const result = await sendVideoMessageWeixin({
-      to: "u", text: "", uploaded: makeUploadedFileInfo(),
-      opts: { baseUrl: "https://api.com" },
-    });
-    expect(result.messageId).toBeDefined();
+  it("refuses to send without contextToken (throws)", async () => {
+    await expect(
+      sendVideoMessageWeixin({
+        to: "u",
+        text: "",
+        uploaded: makeUploadedFileInfo(),
+        opts: { baseUrl: "https://api.com" },
+      }),
+    ).rejects.toThrow(/contextToken missing/);
+    expect(mockSendMessageApi).not.toHaveBeenCalled();
   });
 
   it("sends video message", async () => {
     mockSendMessageApi.mockResolvedValue(undefined);
     const result = await sendVideoMessageWeixin({
-      to: "user1", text: "", uploaded: makeUploadedFileInfo({ playLength: 30 }),
+      to: "user1",
+      text: "",
+      uploaded: makeUploadedFileInfo(),
       opts: { baseUrl: "https://api.com", contextToken: "ctx" },
     });
     expect(result.messageId).toBeDefined();
   });
 
-  it("sends video message with thumbnail", async () => {
+  it("uses the ciphertext size in the video payload", async () => {
     mockSendMessageApi.mockResolvedValue(undefined);
-    const uploaded = makeUploadedFileInfo({
-      playLength: 30,
-      thumb: {
-        filekey: "fk",
-        downloadEncryptedQueryParam: "tp",
-        aeskey: "0123456789abcdef0123456789abcdef",
-        fileSize: 200,
-        fileSizeCiphertext: 208,
-        width: 300,
-        height: 225,
-      },
-    });
-    const result = await sendVideoMessageWeixin({
-      to: "user1", text: "", uploaded,
+    await sendVideoMessageWeixin({
+      to: "user1",
+      text: "",
+      uploaded: makeUploadedFileInfo({ fileSizeCiphertext: 2048 }),
       opts: { baseUrl: "https://api.com", contextToken: "ctx" },
     });
-    expect(result.messageId).toBeDefined();
+    expect(mockSendMessageApi.mock.calls[0][0].body.msg.item_list[0].video_item?.video_size).toBe(2048);
   });
 });
 
 describe("sendFileMessageWeixin", () => {
-  it("sends without contextToken (no throw)", async () => {
-    mockSendMessageApi.mockResolvedValueOnce(undefined);
-    const result = await sendFileMessageWeixin({
-      to: "u", text: "", fileName: "file.pdf", uploaded: makeUploadedFileInfo(),
-      opts: { baseUrl: "https://api.com" },
-    });
-    expect(result.messageId).toBeDefined();
+  it("refuses to send without contextToken (throws)", async () => {
+    await expect(
+      sendFileMessageWeixin({
+        to: "u",
+        text: "",
+        fileName: "file.pdf",
+        uploaded: makeUploadedFileInfo(),
+        opts: { baseUrl: "https://api.com" },
+      }),
+    ).rejects.toThrow(/contextToken missing/);
+    expect(mockSendMessageApi).not.toHaveBeenCalled();
   });
 
   it("sends file message", async () => {
     mockSendMessageApi.mockResolvedValue(undefined);
     const result = await sendFileMessageWeixin({
-      to: "user1", text: "see attached", fileName: "doc.pdf", uploaded: makeUploadedFileInfo(),
+      to: "user1",
+      text: "see attached",
+      fileName: "doc.pdf",
+      uploaded: makeUploadedFileInfo(),
       opts: { baseUrl: "https://api.com", contextToken: "ctx" },
     });
     expect(result.messageId).toBeDefined();
     expect(mockSendMessageApi).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe("missing contextToken refuses to send (silent-drop fix, upstream #247)", () => {
+  const FULL_ID = "o9cq806PLhqoC5-fjuN63zCyAInQ@im.wechat";
+
+  it("sendMessageWeixin throws and does not call the backend", async () => {
+    await expect(sendMessageWeixin({ to: FULL_ID, text: "hi", opts: { baseUrl: "https://api.com" } })).rejects.toThrow(
+      /contextToken missing/,
+    );
+    expect(mockSendMessageApi).not.toHaveBeenCalled();
+  });
+
+  it("sendMessageItemWeixin throws and does not call the backend", async () => {
+    await expect(
+      sendMessageItemWeixin({
+        to: FULL_ID,
+        item: {
+          type: MessageItemType.TOOL_CALL_START,
+          is_completed: false,
+          tool_call_start_item: { tool_name: "read", tool_call_id: "tool:call-1" },
+        },
+        opts: { baseUrl: "https://api.com" },
+      }),
+    ).rejects.toThrow(/contextToken missing/);
+    expect(mockSendMessageApi).not.toHaveBeenCalled();
+  });
+
+  it("sendImageMessageWeixin throws and does not call the backend", async () => {
+    await expect(
+      sendImageMessageWeixin({
+        to: FULL_ID,
+        text: "",
+        uploaded: makeUploadedFileInfo(),
+        opts: { baseUrl: "https://api.com" },
+      }),
+    ).rejects.toThrow(/contextToken missing/);
+    expect(mockSendMessageApi).not.toHaveBeenCalled();
+  });
+
+  it("sendVideoMessageWeixin throws and does not call the backend", async () => {
+    await expect(
+      sendVideoMessageWeixin({
+        to: FULL_ID,
+        text: "",
+        uploaded: makeUploadedFileInfo(),
+        opts: { baseUrl: "https://api.com" },
+      }),
+    ).rejects.toThrow(/contextToken missing/);
+    expect(mockSendMessageApi).not.toHaveBeenCalled();
+  });
+
+  it("sendFileMessageWeixin throws and does not call the backend", async () => {
+    await expect(
+      sendFileMessageWeixin({
+        to: FULL_ID,
+        text: "",
+        fileName: "f.pdf",
+        uploaded: makeUploadedFileInfo(),
+        opts: { baseUrl: "https://api.com" },
+      }),
+    ).rejects.toThrow(/contextToken missing/);
+    expect(mockSendMessageApi).not.toHaveBeenCalled();
+  });
+
+  it("does not leak the full recipient id in the thrown error (privacy)", async () => {
+    let thrown: unknown;
+    try {
+      await sendMessageWeixin({ to: FULL_ID, text: "hi", opts: { baseUrl: "https://api.com" } });
+    } catch (e) {
+      thrown = e;
+    }
+    expect(thrown).toBeInstanceOf(Error);
+    const msg = thrown instanceof Error ? thrown.message : String(thrown);
+    // the recipient peer id must never appear verbatim in the error surface
+    expect(msg).not.toContain(FULL_ID);
+    expect(msg).toMatch(/contextToken missing/);
+  });
+
+  it("counterexample: a valid contextToken sends successfully", async () => {
+    mockSendMessageApi.mockResolvedValueOnce(undefined);
+    const result = await sendMessageWeixin({
+      to: "user1",
+      text: "hi",
+      opts: { baseUrl: "https://api.com", contextToken: "ctx" },
+    });
+    expect(result.messageId).toBeDefined();
+    expect(mockSendMessageApi).toHaveBeenCalledOnce();
   });
 });

--- a/src/messaging/send.ts
+++ b/src/messaging/send.ts
@@ -1,12 +1,12 @@
 import type { ReplyPayload } from "openclaw/plugin-sdk/reply-runtime";
-
-import { sendMessage as sendMessageApi } from "../api/api.js";
 import type { WeixinApiOptions } from "../api/api.js";
-import { logger } from "../util/logger.js";
-import { generateId } from "../util/random.js";
+import { sendMessage as sendMessageApi } from "../api/api.js";
 import type { MessageItem, SendMessageReq } from "../api/types.js";
 import { MessageItemType, MessageState, MessageType } from "../api/types.js";
 import type { UploadedFileInfo } from "../cdn/upload.js";
+import { logger } from "../util/logger.js";
+import { generateId } from "../util/random.js";
+import { redactToken } from "../util/redact.js";
 
 export { StreamingMarkdownFilter } from "./markdown-filter.js";
 
@@ -28,9 +28,7 @@ function buildTextMessageReq(params: {
   clientId: string;
 }): SendMessageReq {
   const { to, text, contextToken, runId, clientId } = params;
-  const item_list: MessageItem[] = text
-    ? [{ type: MessageItemType.TEXT, text_item: { text } }]
-    : [];
+  const item_list: MessageItem[] = text ? [{ type: MessageItemType.TEXT, text_item: { text } }] : [];
   return {
     msg: {
       from_user_id: "",
@@ -73,9 +71,10 @@ export async function sendMessageWeixin(params: {
 }): Promise<{ messageId: string }> {
   const { to, text, opts } = params;
   if (!opts.contextToken) {
-    const e = new Error(`[openclaw-weixin] sendMessageWeixin: contextToken missing for to=${to} — refusing to send (silent-drop risk; see upstream issue)`);
-    logger.error(e.message);
-    throw e;
+    logger.error("sendMessageWeixin: contextToken missing — refusing to send (silent-drop risk; upstream #247)");
+    throw new Error(
+      "[openclaw-weixin] sendMessageWeixin: contextToken missing — refusing to send to avoid silent-drop (upstream issue #247)",
+    );
   }
   const clientId = generateClientId();
   const req = buildSendMessageReq({
@@ -93,7 +92,7 @@ export async function sendMessageWeixin(params: {
       body: req,
     });
   } catch (err) {
-    logger.error(`sendMessageWeixin: failed to=${to} clientId=${clientId} err=${String(err)}`);
+    logger.error(`sendMessageWeixin: failed to=${redactToken(to)} clientId=${clientId} err=${String(err)}`);
     throw err;
   }
   return { messageId: clientId };
@@ -109,9 +108,10 @@ export async function sendMessageItemWeixin(params: {
 }): Promise<{ messageId: string }> {
   const { to, item, opts } = params;
   if (!opts.contextToken) {
-    const e = new Error(`[openclaw-weixin] sendMessageItemWeixin: contextToken missing for to=${to} — refusing to send (silent-drop risk; see upstream issue)`);
-    logger.error(e.message);
-    throw e;
+    logger.error("sendMessageItemWeixin: contextToken missing — refusing to send (silent-drop risk; upstream #247)");
+    throw new Error(
+      "[openclaw-weixin] sendMessageItemWeixin: contextToken missing — refusing to send to avoid silent-drop (upstream issue #247)",
+    );
   }
   const clientId = params.clientId ?? generateClientId();
   const req: SendMessageReq = {
@@ -135,7 +135,7 @@ export async function sendMessageItemWeixin(params: {
     });
   } catch (err) {
     logger.error(
-      `${params.label ?? "sendMessageItemWeixin"}: failed to=${to} clientId=${clientId} err=${String(err)}`,
+      `${params.label ?? "sendMessageItemWeixin"}: failed to=${redactToken(to)} clientId=${clientId} err=${String(err)}`,
     );
     throw err;
   }
@@ -185,14 +185,12 @@ async function sendMediaItems(params: {
         body: req,
       });
     } catch (err) {
-      logger.error(
-        `${label}: failed to=${to} clientId=${lastClientId} err=${String(err)}`,
-      );
+      logger.error(`${label}: failed to=${redactToken(to)} clientId=${lastClientId} err=${String(err)}`);
       throw err;
     }
   }
 
-  logger.info(`${label}: success to=${to} clientId=${lastClientId}`);
+  logger.info(`${label}: success to=${redactToken(to)} clientId=${lastClientId}`);
   return { messageId: lastClientId };
 }
 
@@ -213,12 +211,13 @@ export async function sendImageMessageWeixin(params: {
 }): Promise<{ messageId: string }> {
   const { to, text, uploaded, opts } = params;
   if (!opts.contextToken) {
-    const e = new Error(`[openclaw-weixin] sendImageMessageWeixin: contextToken missing for to=${to} — refusing to send (silent-drop risk; see upstream issue)`);
-    logger.error(e.message);
-    throw e;
+    logger.error("sendImageMessageWeixin: contextToken missing — refusing to send (silent-drop risk; upstream #247)");
+    throw new Error(
+      "[openclaw-weixin] sendImageMessageWeixin: contextToken missing — refusing to send to avoid silent-drop (upstream issue #247)",
+    );
   }
   logger.info(
-    `sendImageMessageWeixin: to=${to} filekey=${uploaded.filekey} fileSize=${uploaded.fileSize} aeskey=present`,
+    `sendImageMessageWeixin: to=${redactToken(to)} filekey=${uploaded.filekey} fileSize=${uploaded.fileSize} aeskey=present`,
   );
 
   const imageItem: MessageItem = {
@@ -249,9 +248,10 @@ export async function sendVideoMessageWeixin(params: {
 }): Promise<{ messageId: string }> {
   const { to, text, uploaded, opts } = params;
   if (!opts.contextToken) {
-    const e = new Error(`[openclaw-weixin] sendVideoMessageWeixin: contextToken missing for to=${to} — refusing to send (silent-drop risk; see upstream issue)`);
-    logger.error(e.message);
-    throw e;
+    logger.error("sendVideoMessageWeixin: contextToken missing — refusing to send (silent-drop risk; upstream #247)");
+    throw new Error(
+      "[openclaw-weixin] sendVideoMessageWeixin: contextToken missing — refusing to send to avoid silent-drop (upstream issue #247)",
+    );
   }
 
   const videoItem: MessageItem = {
@@ -283,9 +283,10 @@ export async function sendFileMessageWeixin(params: {
 }): Promise<{ messageId: string }> {
   const { to, text, fileName, uploaded, opts } = params;
   if (!opts.contextToken) {
-    const e = new Error(`[openclaw-weixin] sendFileMessageWeixin: contextToken missing for to=${to} — refusing to send (silent-drop risk; see upstream issue)`);
-    logger.error(e.message);
-    throw e;
+    logger.error("sendFileMessageWeixin: contextToken missing — refusing to send (silent-drop risk; upstream #247)");
+    throw new Error(
+      "[openclaw-weixin] sendFileMessageWeixin: contextToken missing — refusing to send to avoid silent-drop (upstream issue #247)",
+    );
   }
   const fileItem: MessageItem = {
     type: MessageItemType.FILE,

--- a/src/messaging/send.ts
+++ b/src/messaging/send.ts
@@ -73,7 +73,9 @@ export async function sendMessageWeixin(params: {
 }): Promise<{ messageId: string }> {
   const { to, text, opts } = params;
   if (!opts.contextToken) {
-    logger.warn(`sendMessageWeixin: contextToken missing for to=${to}, sending without context`);
+    const e = new Error(`[openclaw-weixin] sendMessageWeixin: contextToken missing for to=${to} — refusing to send (silent-drop risk; see upstream issue)`);
+    logger.error(e.message);
+    throw e;
   }
   const clientId = generateClientId();
   const req = buildSendMessageReq({
@@ -107,7 +109,9 @@ export async function sendMessageItemWeixin(params: {
 }): Promise<{ messageId: string }> {
   const { to, item, opts } = params;
   if (!opts.contextToken) {
-    logger.warn(`sendMessageItemWeixin: contextToken missing for to=${to}, sending without context`);
+    const e = new Error(`[openclaw-weixin] sendMessageItemWeixin: contextToken missing for to=${to} — refusing to send (silent-drop risk; see upstream issue)`);
+    logger.error(e.message);
+    throw e;
   }
   const clientId = params.clientId ?? generateClientId();
   const req: SendMessageReq = {
@@ -209,7 +213,9 @@ export async function sendImageMessageWeixin(params: {
 }): Promise<{ messageId: string }> {
   const { to, text, uploaded, opts } = params;
   if (!opts.contextToken) {
-    logger.warn(`sendImageMessageWeixin: contextToken missing for to=${to}, sending without context`);
+    const e = new Error(`[openclaw-weixin] sendImageMessageWeixin: contextToken missing for to=${to} — refusing to send (silent-drop risk; see upstream issue)`);
+    logger.error(e.message);
+    throw e;
   }
   logger.info(
     `sendImageMessageWeixin: to=${to} filekey=${uploaded.filekey} fileSize=${uploaded.fileSize} aeskey=present`,
@@ -243,7 +249,9 @@ export async function sendVideoMessageWeixin(params: {
 }): Promise<{ messageId: string }> {
   const { to, text, uploaded, opts } = params;
   if (!opts.contextToken) {
-    logger.warn(`sendVideoMessageWeixin: contextToken missing for to=${to}, sending without context`);
+    const e = new Error(`[openclaw-weixin] sendVideoMessageWeixin: contextToken missing for to=${to} — refusing to send (silent-drop risk; see upstream issue)`);
+    logger.error(e.message);
+    throw e;
   }
 
   const videoItem: MessageItem = {
@@ -275,7 +283,9 @@ export async function sendFileMessageWeixin(params: {
 }): Promise<{ messageId: string }> {
   const { to, text, fileName, uploaded, opts } = params;
   if (!opts.contextToken) {
-    logger.warn(`sendFileMessageWeixin: contextToken missing for to=${to}, sending without context`);
+    const e = new Error(`[openclaw-weixin] sendFileMessageWeixin: contextToken missing for to=${to} — refusing to send (silent-drop risk; see upstream issue)`);
+    logger.error(e.message);
+    throw e;
   }
   const fileItem: MessageItem = {
     type: MessageItemType.FILE,


### PR DESCRIPTION
# fix(weixin): refuse to send when contextToken is missing instead of silent-drop

## Summary

`sendMessageWeixin` / `sendMessageItemWeixin` / `sendImageMessageWeixin` /
`sendVideoMessageWeixin` / `sendFileMessageWeixin` currently only `logger.warn`
when `opts.contextToken` is missing, then send the request anyway. The WeChat
iLink backend **silently discards** messages sent without a (fresh) context
token — it returns HTTP 200 with no body and the message never reaches the
user. The function then returns a self-generated `clientId` as `messageId`,
so every caller up the stack (channel `sendText`/`sendMedia`, `emitWeixinMessageSent`)
reports **success** while nothing was delivered. This is a silent-failure bug.

This PR changes the 5 `contextToken missing` sites to **throw** a typed error
instead of warning-and-sending. Callers already wrap these in `try/catch` and
report delivery failure, so the throw is handled correctly.

## Root cause

- `src/messaging/send.ts`: `if (!opts.contextToken) { logger.warn(...); }`
  then `await sendMessageApi(...)` is still called.
- `sendMessageApi` only rejects on transport/HTTP errors; a 200-with-empty-body
  "silent drop" is treated as success.
- The function returns `{ messageId: clientId }` where `clientId` is locally
  generated, not an acknowledgement from the server.
- Result: command exits 0, all layers report success, user receives nothing.

## Changes

In all 5 send functions, replace:

```ts
if (!opts.contextToken) {
  logger.warn(`<fn>: contextToken missing for to=${to}, sending without context`);
}
```

with:

```ts
if (!opts.contextToken) {
  const e = new Error(`[openclaw-weixin] <fn>: contextToken missing for to=${to} — refusing to send (silent-drop risk; see upstream issue)`);
  logger.error(e.message);
  throw e;
}
```

(`<fn>` is the respective function name.)

## Testing

- Verified the 5 `contextToken missing` branches are the only silent-drop paths
  in `src/messaging/send.ts`.
- `git apply --check` passes cleanly on the published `2.4.6` source
  (`packages/openclaw-weixin/src/messaging/send.ts`).
- Callers (`channel.ts` `sendText`/`sendMedia`) already `try/catch` and call
  `emitWeixinMessageSent(success: false)` on throw, so behaviour is correct.

## Limitations / follow-up

- This covers the **missing** `contextToken` case. It does **not** cover a
  token that is *present but stale* (not refreshed by a recent inbound
  message) — the backend still silently drops those. A more complete fix would
  also refuse/retry when the cached token age exceeds a threshold (e.g. read
  from the token store). Happy to follow up if maintainers want that scope.
- The robust delivery path in practice is the WeCom (企业微信) webhook channel,
  which is unaffected by the iLink token lifecycle.

## Reproduction & patch regeneration

### How to reproduce the bug
1. Configure an OpenClaw weixin account whose `contextToken` is missing or
   stale — i.e. a bot that has **not** received a recent inbound message from
   that user. The iLink backend only issues a fresh token per inbound message,
   so a quiet bot accumulates a missing/stale token.
2. Trigger any outbound send: `openclaw message send`, a cron job with
   `deliver: weixin`, or an `@bot` reply through the weixin channel.
3. Observe: the CLI exits 0, `emitWeixinMessageSent(success: true)` fires, yet
   the recipient receives **nothing**. The backend returned HTTP 200 with an
   empty body and silently dropped the message. That is the silent-failure bug.

### How to regenerate this patch for a new version
The fix is mechanical (5 identical `warn` → `throw` sites), so a helper script
is provided for regression testing against future releases:

```bash
# from the repo root of a fork of @tencent-weixin/openclaw-weixin
python3 gen_patch.py packages/openclaw-weixin/src/messaging/send.ts
# -> writes packages/openclaw-weixin/src/messaging/pr-patch-send-contexttoken.patch
```

`gen_patch.py` rewrites the 5 `contextToken missing` branches and emits a
unified diff with **LF** line endings (so it applies cleanly on Linux/macOS).
It is a regeneration/regression helper only — **not** the reproduction steps
above. The script accepts the path to `send.ts` as its only argument; if it
reports a count other than 5, the source version has drifted and the patch
needs a manual review.

### Verify before opening the PR
```bash
cd packages/openclaw-weixin
git apply --check pr-patch-send-contexttoken.patch   # must print nothing / exit 0
```

## Checklist

- [x] `git apply --check` passes on `2.4.6`
- [x] Only the 5 silent-drop sites changed; no behaviour change for valid tokens
- [x] Callers handle the throw correctly
