### PR TITLE
fix(auth): persist stable --account alias on QR login

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@
 
 This project follows the [Keep a Changelog](https://keepachangelog.com/) format.
 
+## [Unreleased]
+
+### Fixed
+
+- **QR login persists stable `--account` alias:** `channels login --account <alias>` now writes credentials under both the normalized bot id and the alias, so multi-account configs resolve without hand-copying hash files. Stale-`userId` cleanup keeps both files. See also community PR [NewFuture/openclaw-weixin#53](https://github.com/NewFuture/openclaw-weixin/pull/53).
+
 ## [2.4.5] - 2026-06-22
 
 ### Added

--- a/CHANGELOG.zh_CN.md
+++ b/CHANGELOG.zh_CN.md
@@ -4,6 +4,12 @@
 
 本项目遵循 [Keep a Changelog](https://keepachangelog.com/) 格式。
 
+## [Unreleased]
+
+### 修复
+
+- **扫码登录持久化稳定 `--account` 别名：** `channels login --account <alias>` 会同时写入 bot id 与别名凭证文件，多账号配置无需再手工复制 hash 文件；同 `userId` 清理会保留这两份。对应社区 PR：[NewFuture/openclaw-weixin#53](https://github.com/NewFuture/openclaw-weixin/pull/53)。
+
 ## [2.4.5] - 2026-06-22
 
 ### 新增

--- a/README.md
+++ b/README.md
@@ -58,11 +58,14 @@ openclaw gateway restart
 
 ## Adding More WeChat Accounts
 
+Prefer a stable `--account` alias so OpenClaw config can bind peers / allowlists by name:
+
 ```bash
-openclaw channels login --channel openclaw-weixin
+openclaw channels login --channel openclaw-weixin --account leader
+openclaw channels login --channel openclaw-weixin --account jinjin
 ```
 
-Each QR code login creates a new account entry, supporting multiple WeChat accounts online simultaneously.
+Each successful login writes credentials under both the server bot id (`hex-im-bot`) and the alias (`leader.json` / `jinjin.json`). Omitting `--account` still creates a new account entry from the bot id alone.
 
 ## Multi-Account Context Isolation
 

--- a/README.zh_CN.md
+++ b/README.zh_CN.md
@@ -57,11 +57,14 @@ openclaw gateway restart
 
 ## 添加更多微信账号
 
+建议使用稳定的 `--account` 别名，便于在 OpenClaw 配置里按名称绑定 peer / allowlist：
+
 ```bash
-openclaw channels login --channel openclaw-weixin
+openclaw channels login --channel openclaw-weixin --account leader
+openclaw channels login --channel openclaw-weixin --account jinjin
 ```
 
-每次扫码登录都会创建一个新的账号条目，支持多个微信号同时在线。
+每次登录成功后，会同时写入服务端 bot id（`hex-im-bot`）与别名（`leader.json` / `jinjin.json`）两份凭证。省略 `--account` 时仍只按 bot id 创建账号条目。
 
 ## 多账号上下文隔离
 

--- a/src/auth/account-store.test.ts
+++ b/src/auth/account-store.test.ts
@@ -120,3 +120,150 @@ describe("clearWeixinAccount", () => {
     expect(() => clearWeixinAccount("nonexistent")).not.toThrow();
   });
 });
+
+describe("clearStaleAccountsForUserId", () => {
+  it("removes only older accounts linked to the same user", async () => {
+    const {
+      saveWeixinAccount,
+      loadWeixinAccount,
+      registerWeixinAccountId,
+      listIndexedWeixinAccountIds,
+      clearStaleAccountsForUserId,
+    } = await loadModule();
+    saveWeixinAccount("account-current", {
+      token: "token-current",
+      userId: "user-shared",
+    });
+    saveWeixinAccount("account-stale", {
+      token: "token-stale",
+      userId: "user-shared",
+    });
+    saveWeixinAccount("account-other", {
+      token: "token-other",
+      userId: "user-other",
+    });
+    registerWeixinAccountId("account-current");
+    registerWeixinAccountId("account-stale");
+    registerWeixinAccountId("account-other");
+    const clearContextTokens = vi.fn();
+
+    clearStaleAccountsForUserId("account-current", "user-shared", clearContextTokens);
+
+    expect(listIndexedWeixinAccountIds()).toEqual(["account-current", "account-other"]);
+    expect(loadWeixinAccount("account-stale")).toBeNull();
+    expect(loadWeixinAccount("account-current")).not.toBeNull();
+    expect(clearContextTokens).toHaveBeenCalledOnce();
+    expect(clearContextTokens).toHaveBeenCalledWith("account-stale");
+  });
+
+  it("keeps both primary and alias when keepAccountIds lists both", async () => {
+    const {
+      saveWeixinAccount,
+      loadWeixinAccount,
+      registerWeixinAccountId,
+      listIndexedWeixinAccountIds,
+      clearStaleAccountsForUserId,
+    } = await loadModule();
+    saveWeixinAccount("bot-im-bot", { token: "tok", userId: "user-a" });
+    saveWeixinAccount("staff", { token: "tok", userId: "user-a" });
+    saveWeixinAccount("stale-im-bot", { token: "old", userId: "user-a" });
+    registerWeixinAccountId("bot-im-bot");
+    registerWeixinAccountId("staff");
+    registerWeixinAccountId("stale-im-bot");
+
+    clearStaleAccountsForUserId(["bot-im-bot", "staff"], "user-a");
+
+    expect(listIndexedWeixinAccountIds()).toEqual(["bot-im-bot", "staff"]);
+    expect(loadWeixinAccount("stale-im-bot")).toBeNull();
+    expect(loadWeixinAccount("staff")?.token).toBe("tok");
+  });
+});
+
+describe("resolveLoginAccountAlias", () => {
+  it("returns a stable human alias distinct from the bot id", async () => {
+    const { resolveLoginAccountAlias } = await loadModule();
+    expect(resolveLoginAccountAlias("collin", "9ff4830b870e-im-bot")).toBe("collin");
+  });
+
+  it("returns null when alias matches the primary bot id", async () => {
+    const { resolveLoginAccountAlias } = await loadModule();
+    expect(resolveLoginAccountAlias("9ff4830b870e-im-bot", "9ff4830b870e-im-bot")).toBeNull();
+    expect(resolveLoginAccountAlias("9ff4830b870e@im.bot", "9ff4830b870e-im-bot")).toBeNull();
+  });
+
+  it("returns null for ephemeral UUID session keys", async () => {
+    const { resolveLoginAccountAlias } = await loadModule();
+    expect(resolveLoginAccountAlias("550e8400-e29b-41d4-a716-446655440000", "bot-im-bot")).toBeNull();
+  });
+});
+
+describe("persistWeixinLoginAccounts", () => {
+  it("writes only the bot id when no stable alias is requested", async () => {
+    const {
+      persistWeixinLoginAccounts,
+      listIndexedWeixinAccountIds,
+      loadWeixinAccount,
+    } = await loadModule();
+    const result = persistWeixinLoginAccounts({
+      botAccountId: "abc@im.bot",
+      token: "tok-1",
+      baseUrl: "https://ilink.example.test",
+      userId: "user-1@im.wechat",
+    });
+
+    expect(result).toEqual({ primaryId: "abc-im-bot", aliasId: null });
+    expect(listIndexedWeixinAccountIds()).toEqual(["abc-im-bot"]);
+    expect(loadWeixinAccount("abc-im-bot")).toMatchObject({
+      token: "tok-1",
+      userId: "user-1@im.wechat",
+    });
+    expect(loadWeixinAccount("collin")).toBeNull();
+  });
+
+  it("writes alias credentials alongside the bot id for multi-account login", async () => {
+    const {
+      persistWeixinLoginAccounts,
+      listIndexedWeixinAccountIds,
+      loadWeixinAccount,
+    } = await loadModule();
+    const result = persistWeixinLoginAccounts({
+      botAccountId: "9ff4830b870e@im.bot",
+      token: "tok-alias",
+      baseUrl: "https://ilink.example.test",
+      userId: "o9cq80zLSSEWjtr2UODlOgvt3pO4@im.wechat",
+      requestedAccountId: "collin",
+    });
+
+    expect(result).toEqual({ primaryId: "9ff4830b870e-im-bot", aliasId: "collin" });
+    expect(listIndexedWeixinAccountIds()).toEqual(["9ff4830b870e-im-bot", "collin"]);
+    expect(loadWeixinAccount("collin")).toMatchObject({
+      token: "tok-alias",
+      userId: "o9cq80zLSSEWjtr2UODlOgvt3pO4@im.wechat",
+    });
+    expect(loadWeixinAccount("9ff4830b870e-im-bot")?.token).toBe("tok-alias");
+  });
+
+  it("does not delete the alias when clearing stale accounts for the same user", async () => {
+    const {
+      saveWeixinAccount,
+      registerWeixinAccountId,
+      persistWeixinLoginAccounts,
+      loadWeixinAccount,
+      listIndexedWeixinAccountIds,
+    } = await loadModule();
+    saveWeixinAccount("old-im-bot", { token: "old", userId: "user-shared@im.wechat" });
+    registerWeixinAccountId("old-im-bot");
+
+    persistWeixinLoginAccounts({
+      botAccountId: "new@im.bot",
+      token: "fresh",
+      userId: "user-shared@im.wechat",
+      requestedAccountId: "staff",
+    });
+
+    expect(loadWeixinAccount("old-im-bot")).toBeNull();
+    expect(loadWeixinAccount("staff")?.token).toBe("fresh");
+    expect(loadWeixinAccount("new-im-bot")?.token).toBe("fresh");
+    expect(listIndexedWeixinAccountIds()).toEqual(["new-im-bot", "staff"]);
+  });
+});

--- a/src/auth/accounts.ts
+++ b/src/auth/accounts.ts
@@ -84,17 +84,26 @@ export function unregisterWeixinAccountId(accountId: string): void {
  * Called after a successful QR login to ensure only the latest account remains
  * for a given WeChat user, preventing ambiguous contextToken matches.
  *
+ * `keepAccountIds` may list both the bot hash id and a stable CLI alias so a
+ * dual-file login (primary + alias) does not delete itself.
+ *
  * @param onClearContextTokens callback to clear context tokens for the removed account
  */
 export function clearStaleAccountsForUserId(
-  currentAccountId: string,
+  keepAccountIds: string | readonly string[],
   userId: string,
   onClearContextTokens?: (accountId: string) => void,
 ): void {
   if (!userId) return;
+  const keep = new Set(
+    (Array.isArray(keepAccountIds) ? keepAccountIds : [keepAccountIds])
+      .map((id) => id.trim())
+      .filter(Boolean),
+  );
+  if (keep.size === 0) return;
   const allIds = listIndexedWeixinAccountIds();
   for (const id of allIds) {
-    if (id === currentAccountId) continue;
+    if (keep.has(id)) continue;
     const data = loadWeixinAccount(id);
     if (data?.userId?.trim() === userId) {
       logger.info(`clearStaleAccountsForUserId: removing stale account=${id} (same userId=${userId})`);
@@ -103,6 +112,79 @@ export function clearStaleAccountsForUserId(
       unregisterWeixinAccountId(id);
     }
   }
+}
+
+/**
+ * True when `requestedAccountId` is a human-stable alias (e.g. `collin`), not the
+ * server bot id and not an ephemeral UUID session key used as login sessionKey.
+ */
+export function resolveLoginAccountAlias(
+  requestedAccountId: string | null | undefined,
+  primaryNormalizedId: string,
+): string | null {
+  const raw = requestedAccountId?.trim();
+  if (!raw) return null;
+  const alias = normalizeAccountId(raw);
+  if (!alias || alias === primaryNormalizedId) return null;
+  // Ephemeral login session keys must never become durable account files.
+  if (/^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(alias)) {
+    return null;
+  }
+  return alias;
+}
+
+export type PersistWeixinLoginAccountsResult = {
+  primaryId: string;
+  aliasId: string | null;
+};
+
+/**
+ * Persist QR-login credentials under the server bot id and, when the caller
+ * passed a stable `--account` alias, also under that alias (same token/userId).
+ *
+ * Multi-account deployments bind OpenClaw config to names like `leader` /
+ * `jinjin`, but iLink returns `hex@im.bot`. Without the alias file,
+ * `channels login --account <alias>` leaves only the hash credential and
+ * alias-based bindings / allowlists cannot resolve the linked userId.
+ */
+export function persistWeixinLoginAccounts(params: {
+  botAccountId: string;
+  token: string;
+  baseUrl?: string;
+  userId?: string;
+  requestedAccountId?: string | null;
+  onClearContextTokens?: (accountId: string) => void;
+}): PersistWeixinLoginAccountsResult {
+  const primaryId = normalizeAccountId(params.botAccountId);
+  if (!primaryId) {
+    throw new Error("weixin: bot accountId is required after login");
+  }
+  const creds = {
+    token: params.token,
+    baseUrl: params.baseUrl,
+    userId: params.userId,
+  };
+  saveWeixinAccount(primaryId, creds);
+
+  const aliasId = resolveLoginAccountAlias(params.requestedAccountId, primaryId);
+  if (aliasId) {
+    saveWeixinAccount(aliasId, creds);
+    logger.info(
+      `persistWeixinLoginAccounts: wrote alias=${aliasId} alongside primary=${primaryId}`,
+    );
+  }
+
+  const keep = aliasId ? [primaryId, aliasId] : [primaryId];
+  if (params.userId?.trim()) {
+    clearStaleAccountsForUserId(keep, params.userId.trim(), params.onClearContextTokens);
+  }
+
+  registerWeixinAccountId(primaryId);
+  if (aliasId) {
+    registerWeixinAccountId(aliasId);
+  }
+
+  return { primaryId, aliasId };
 }
 
 // ---------------------------------------------------------------------------

--- a/src/channel.ts
+++ b/src/channel.ts
@@ -1,17 +1,14 @@
 import path from "node:path";
 
 import type { ChannelPlugin, OpenClawConfig, PluginRuntime } from "openclaw/plugin-sdk/core";
-import { normalizeAccountId } from "openclaw/plugin-sdk/account-id";
 import { resolvePreferredOpenClawTmpDir } from "openclaw/plugin-sdk/infra-runtime";
 
 import {
-  registerWeixinAccountId,
   loadWeixinAccount,
-  saveWeixinAccount,
   listWeixinAccountIds,
+  persistWeixinLoginAccounts,
   resolveWeixinAccount,
   triggerWeixinChannelReload,
-  clearStaleAccountsForUserId,
   DEFAULT_BASE_URL,
 } from "./auth/accounts.js";
 import type { ResolvedWeixinAccount } from "./auth/accounts.js";
@@ -359,20 +356,23 @@ export const weixinPlugin: ChannelPlugin<ResolvedWeixinAccount> = {
 
       if (waitResult.connected && waitResult.botToken && waitResult.accountId) {
         try {
-          // Normalize the raw ilink_bot_id (e.g. "hex@im.bot") to a filesystem-safe
-          // key (e.g. "hex-im-bot") so account files have no special chars.
-          const normalizedId = normalizeAccountId(waitResult.accountId);
-          saveWeixinAccount(normalizedId, {
+          // Persist under the server bot id and, when CLI/gateway passed a stable
+          // `--account` alias (e.g. collin), also under that alias so multi-account
+          // configs can resolve credentials without hand-copying hash files.
+          const { primaryId, aliasId } = persistWeixinLoginAccounts({
+            botAccountId: waitResult.accountId,
             token: waitResult.botToken,
             baseUrl: waitResult.baseUrl,
             userId: waitResult.userId,
+            requestedAccountId: account.accountId,
+            onClearContextTokens: clearContextTokensForAccount,
           });
-          registerWeixinAccountId(normalizedId);
-          if (waitResult.userId) {
-            clearStaleAccountsForUserId(normalizedId, waitResult.userId, clearContextTokensForAccount);
-          }
           void triggerWeixinChannelReload();
-          log(`\n已将此 OpenClaw 连接到微信。`);
+          log(
+            aliasId
+              ? `\n已将此 OpenClaw 连接到微信（账号 ${aliasId} → ${primaryId}）。`
+              : `\n已将此 OpenClaw 连接到微信。`,
+          );
         } catch (err) {
           logger.error(
             `auth.login: failed to save account data accountId=${waitResult.accountId} err=${String(err)}`,
@@ -517,18 +517,20 @@ export const weixinPlugin: ChannelPlugin<ResolvedWeixinAccount> = {
 
       if (result.connected && result.botToken && result.accountId) {
         try {
-          const normalizedId = normalizeAccountId(result.accountId);
-          saveWeixinAccount(normalizedId, {
+          const { primaryId, aliasId } = persistWeixinLoginAccounts({
+            botAccountId: result.accountId,
             token: result.botToken,
             baseUrl: result.baseUrl,
             userId: result.userId,
+            requestedAccountId: params.accountId,
+            onClearContextTokens: clearContextTokensForAccount,
           });
-          registerWeixinAccountId(normalizedId);
-          if (result.userId) {
-            clearStaleAccountsForUserId(normalizedId, result.userId, clearContextTokensForAccount);
-          }
           triggerWeixinChannelReload();
-          logger.info(`loginWithQrWait: saved account data for accountId=${normalizedId}`);
+          logger.info(
+            aliasId
+              ? `loginWithQrWait: saved account data primary=${primaryId} alias=${aliasId}`
+              : `loginWithQrWait: saved account data for accountId=${primaryId}`,
+          );
         } catch (err) {
           logger.error(`loginWithQrWait: failed to save account data err=${String(err)}`);
         }


### PR DESCRIPTION
## Summary
- On QR login, persist credentials under both the stable CLI `--account` alias and the normalized `ilink_bot_id`, so multi-account configs resolve without hand-copying JSON files.
- Stale-`userId` cleanup keeps the primary + alias credential files.
- Docs: CHANGELOG (en/zh) + multi-account README notes.

## Motivation
`openclaw channels login --channel openclaw-weixin --account collin` currently only writes `normalizeAccountId(ilink_bot_id).json`. Operators who bind peers by readable accountId then need a manual `cp` of the credential file. This PR makes login write both paths.

## Upstream
Primary community PR: https://github.com/NewFuture/openclaw-weixin/pull/53

## Test plan
- [x] `npx vitest run src/auth/account-store.test.ts` (18 pass)
- [ ] Manual: `channels login --account <alias>` → both `<alias>.json` and `<botHash>.json` exist
- [ ] Manual: gateway resolves peer binding by alias without copying files

## Notes
- No version bump (prefer maintainer release process).

Made with [Cursor](https://cursor.com)