### PR TITLE
fix: support current OpenClaw channel SDK exports

### DIFF
--- a/src/messaging/process-message.ts
+++ b/src/messaging/process-message.ts
@@ -1,7 +1,6 @@
 import path from "node:path";
 import { randomUUID } from "node:crypto";
 
-import { createTypingCallbacks } from "openclaw/plugin-sdk/channel-runtime";
 import {
   resolveSenderCommandAuthorizationWithRuntime,
   resolveDirectDmAuthorizationOutcome,
@@ -35,6 +34,9 @@ import { StreamingMarkdownFilter } from "./markdown-filter.js";
 import { sendMessageWeixin } from "./send.js";
 import { WeixinReplyProgressSender } from "./reply-progress-sender.js";
 import { handleSlashCommand } from "./slash-commands.js";
+import { loadCreateTypingCallbacks } from "./typing-callbacks.js";
+
+const createTypingCallbacks = await loadCreateTypingCallbacks();
 
 const MEDIA_OUTBOUND_TEMP_DIR = path.join(resolvePreferredOpenClawTmpDir(), "weixin/media/outbound-temp");
 

--- a/src/messaging/typing-callbacks.test.ts
+++ b/src/messaging/typing-callbacks.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { loadCreateTypingCallbacks } from "./typing-callbacks.js";
+
+function missingExportError(): Error {
+  return Object.assign(new Error("Package subpath is not defined by exports"), {
+    code: "ERR_PACKAGE_PATH_NOT_EXPORTED",
+  });
+}
+
+describe("loadCreateTypingCallbacks", () => {
+  it("loads createTypingCallbacks from the installed host", async () => {
+    await expect(loadCreateTypingCallbacks()).resolves.toEqual(expect.any(Function));
+  });
+
+  it("loads the canonical channel-outbound export", async () => {
+    const createTypingCallbacks = vi.fn();
+    const importModule = vi.fn().mockResolvedValue({ createTypingCallbacks });
+
+    await expect(loadCreateTypingCallbacks(importModule)).resolves.toBe(createTypingCallbacks);
+    expect(importModule).toHaveBeenCalledOnce();
+    expect(importModule).toHaveBeenCalledWith("openclaw/plugin-sdk/channel-outbound");
+  });
+
+  it("falls back for hosts that predate channel-outbound", async () => {
+    const createTypingCallbacks = vi.fn();
+    const importModule = vi
+      .fn()
+      .mockRejectedValueOnce(missingExportError())
+      .mockResolvedValueOnce({ createTypingCallbacks });
+
+    await expect(loadCreateTypingCallbacks(importModule)).resolves.toBe(createTypingCallbacks);
+    expect(importModule).toHaveBeenNthCalledWith(1, "openclaw/plugin-sdk/channel-outbound");
+    expect(importModule).toHaveBeenNthCalledWith(2, "openclaw/plugin-sdk/channel-runtime");
+  });
+
+  it("recognizes Vite's missing export error", async () => {
+    const createTypingCallbacks = vi.fn();
+    const importModule = vi
+      .fn()
+      .mockRejectedValueOnce(
+        new Error(
+          'Missing "./plugin-sdk/channel-outbound" specifier in "openclaw" package',
+        ),
+      )
+      .mockResolvedValueOnce({ createTypingCallbacks });
+
+    await expect(loadCreateTypingCallbacks(importModule)).resolves.toBe(createTypingCallbacks);
+  });
+
+  it("does not hide failures from an available canonical module", async () => {
+    const loadError = new Error("module initialization failed");
+    const importModule = vi.fn().mockRejectedValue(loadError);
+
+    await expect(loadCreateTypingCallbacks(importModule)).rejects.toBe(loadError);
+    expect(importModule).toHaveBeenCalledOnce();
+  });
+
+});

--- a/src/messaging/typing-callbacks.ts
+++ b/src/messaging/typing-callbacks.ts
@@ -1,0 +1,32 @@
+import type { createTypingCallbacks as CreateTypingCallbacks } from "openclaw/plugin-sdk/channel-message";
+
+type ModuleImporter = (specifier: string) => Promise<unknown>;
+const CHANNEL_OUTBOUND_MODULE = "openclaw/plugin-sdk/channel-outbound";
+const LEGACY_CHANNEL_RUNTIME_MODULE = "openclaw/plugin-sdk/channel-runtime";
+
+function isMissingPackageExport(error: unknown): boolean {
+  if (!(error instanceof Error)) return false;
+  return (
+    ("code" in error && error.code === "ERR_PACKAGE_PATH_NOT_EXPORTED") ||
+    /Missing .*plugin-sdk\/channel-outbound.* specifier/.test(error.message)
+  );
+}
+
+export async function loadCreateTypingCallbacks(
+  importModule: ModuleImporter = (specifier) => import(specifier),
+): Promise<typeof CreateTypingCallbacks> {
+  try {
+    const module = await importModule(CHANNEL_OUTBOUND_MODULE) as {
+      createTypingCallbacks: typeof CreateTypingCallbacks;
+    };
+    return module.createTypingCallbacks;
+  } catch (error) {
+    // Hosts before channel-outbound shipped still satisfy the plugin's >=2026.5.12 contract.
+    if (!isMissingPackageExport(error)) throw error;
+  }
+
+  const legacyModule = await importModule(LEGACY_CHANNEL_RUNTIME_MODULE) as {
+    createTypingCallbacks: typeof CreateTypingCallbacks;
+  };
+  return legacyModule.createTypingCallbacks;
+}


### PR DESCRIPTION
## Summary

- load `createTypingCallbacks` from the canonical `openclaw/plugin-sdk/channel-outbound` entrypoint
- fall back to the legacy `channel-runtime` entrypoint only when an older supported host does not export `channel-outbound`
- cover current and legacy host resolution plus non-export loader failures

## Why

OpenClaw removed `openclaw/plugin-sdk/channel-runtime` in `2026.7.2-beta.4`. As a result, `@tencent-weixin/openclaw-weixin@2.4.6` cannot start on current beta hosts, including `2026.7.2-beta.7`.

A direct import replacement would fix current hosts but break the plugin's existing `openclaw >=2026.5.12` compatibility contract because those older hosts do not export `channel-outbound`. The narrow resolver uses the canonical entrypoint first and retains the old entrypoint only for that declared compatibility range.

Related: openclaw/openclaw#115478

## Validation

- `npm run typecheck` with `openclaw@2026.5.12`
- `npm run build` with `openclaw@2026.5.12`
- resolver tests against real `openclaw@2026.5.12` and `openclaw@2026.7.2-beta.7` installs
- 402 tests passed across 28 test files
- installed the packed patch through `openclaw plugins install` on `2026.7.2-beta.7`; after a gateway restart, the Weixin long-poll account reports `running=true`, `reconnectAttempts=0`, and `lastError=null`

`npm test` still exits nonzero on the repository's existing global branch coverage threshold: observed 89.14%, required 90%. The new resolver itself is fully covered except for the non-Error guard branch.
