### PR TITLE
fix(security): redact credentials and CDN secrets from logs

### DIFF
--- a/src/api/api.test.ts
+++ b/src/api/api.test.ts
@@ -75,6 +75,22 @@ describe("getUpdates", () => {
     await expect(getUpdates({ baseUrl: "https://api.example.com" })).rejects.toThrow("getUpdates 500");
   });
 
+  it("redacts credentials returned in non-ok responses", async () => {
+    mockFetch.mockResolvedValueOnce(
+      mockResponse({ bot_token: "response-secret", errmsg: "failed" }, 500, false),
+    );
+
+    let thrown = "";
+    try {
+      await getUpdates({ baseUrl: "https://api.example.com" });
+    } catch (err) {
+      thrown = String(err);
+    }
+
+    expect(thrown).toContain('"bot_token":"<redacted>"');
+    expect(thrown).not.toContain("response-secret");
+  });
+
   it("returns empty response on abort/timeout", async () => {
     const abortErr = new Error("AbortError");
     abortErr.name = "AbortError";

--- a/src/api/api.ts
+++ b/src/api/api.ts
@@ -321,7 +321,7 @@ export async function apiGetFetch(params: {
     const rawText = await res.text();
     logger.debug(`${params.label} status=${res.status} raw=${redactBody(rawText)}`);
     if (!res.ok) {
-      throw new Error(`${params.label} ${res.status}: ${rawText}`);
+      throw new Error(`${params.label} ${res.status}: ${redactBody(rawText)}`);
     }
     return rawText;
   } catch (err) {
@@ -406,7 +406,7 @@ export async function apiPostFetch(params: {
     const rawText = await res.text();
     logger.debug(`${params.label} status=${res.status} raw=${redactBody(rawText)}`);
     if (!res.ok) {
-      throw new Error(`${params.label} ${res.status}: ${rawText}`);
+      throw new Error(`${params.label} ${res.status}: ${redactBody(rawText)}`);
     }
     return rawText;
   } catch (err) {

--- a/src/api/config-cache.test.ts
+++ b/src/api/config-cache.test.ts
@@ -32,6 +32,13 @@ describe("WeixinConfigManager", () => {
     expect(logFn).toHaveBeenCalled();
   });
 
+  it("uses an empty typing ticket when a successful response omits it", async () => {
+    mockGetConfig.mockResolvedValueOnce({ ret: 0 });
+    const mgr = new WeixinConfigManager({ baseUrl: "https://api.com" }, vi.fn());
+
+    await expect(mgr.getForUser("user1")).resolves.toEqual({ typingTicket: "" });
+  });
+
   it("returns cached config on subsequent calls within TTL", async () => {
     mockGetConfig.mockResolvedValueOnce({ ret: 0, typing_ticket: "ticket-1" });
     const mgr = new WeixinConfigManager({ baseUrl: "https://api.com" }, vi.fn());

--- a/src/auth/login-qr.ts
+++ b/src/auth/login-qr.ts
@@ -3,7 +3,7 @@ import { randomUUID } from "node:crypto";
 import { apiGetFetch, apiPostFetch } from "../api/api.js";
 import { listIndexedWeixinAccountIds, loadWeixinAccount } from "./accounts.js";
 import { logger } from "../util/logger.js";
-import { redactToken } from "../util/redact.js";
+import { redactBody, redactToken } from "../util/redact.js";
 
 type ActiveLogin = {
   sessionKey: string;
@@ -122,7 +122,7 @@ async function pollQRStatus(apiBaseUrl: string, qrcode: string, verifyCode?: str
       timeoutMs: QR_LONG_POLL_TIMEOUT_MS,
       label: "pollQRStatus",
     });
-    logger.debug(`pollQRStatus: body=${rawText.substring(0, 200)}`);
+    logger.debug(`pollQRStatus: body=${redactBody(rawText)}`);
     return JSON.parse(rawText) as StatusResponse;
   } catch (err) {
     if (err instanceof Error && err.name === "AbortError") {

--- a/src/auth/pairing.test.ts
+++ b/src/auth/pairing.test.ts
@@ -61,6 +61,12 @@ describe("resolveFrameworkAllowFromPath", () => {
     // Only [\\/:*?"<>|] and ".." are replaced; @ and dots are preserved
     expect(result).toContain("openclaw-weixin-abc@im.bot-allowFrom.json");
   });
+
+  it("rejects empty or fully unsafe account IDs", async () => {
+    const { resolveFrameworkAllowFromPath } = await loadModule();
+    expect(() => resolveFrameworkAllowFromPath("   ")).toThrow("invalid key");
+    expect(() => resolveFrameworkAllowFromPath("/")).toThrow("invalid key");
+  });
 });
 
 describe("registerUserInFrameworkStore", () => {

--- a/src/cdn/pic-decrypt.test.ts
+++ b/src/cdn/pic-decrypt.test.ts
@@ -1,0 +1,82 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const loggerMock = vi.hoisted(() => ({
+  debug: vi.fn(),
+  error: vi.fn(),
+}));
+
+vi.mock("../util/logger.js", () => ({ logger: loggerMock }));
+
+import { downloadAndDecryptBuffer, downloadPlainCdnBuffer } from "./pic-decrypt.js";
+
+describe("CDN download log redaction", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    loggerMock.debug.mockReset();
+    loggerMock.error.mockReset();
+  });
+
+  it("does not expose signed CDN query parameters in network error logs", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockRejectedValue(new Error("network unavailable")));
+    const fullUrl = "https://cdn.example/download?signature=very-secret&token=also-secret";
+
+    await expect(
+      downloadPlainCdnBuffer("encrypted-param", "https://cdn.example", "test", fullUrl),
+    ).rejects.toThrow("network unavailable");
+
+    const messages = [
+      ...loggerMock.debug.mock.calls,
+      ...loggerMock.error.mock.calls,
+    ].flat().join("\n");
+    expect(messages).toContain("https://cdn.example/download?<redacted>");
+    expect(messages).not.toContain("very-secret");
+    expect(messages).not.toContain("also-secret");
+  });
+
+  it("does not include malformed AES key material in errors", async () => {
+    const invalidKey = Buffer.from("secret-key-material").toString("base64");
+
+    await expect(
+      downloadAndDecryptBuffer(
+        "encrypted-param",
+        invalidKey,
+        "https://cdn.example",
+        "test",
+      ),
+    ).rejects.toThrow("inputLen=");
+
+    const messages = loggerMock.error.mock.calls.flat().join("\n");
+    expect(messages).not.toContain(invalidKey);
+    expect(messages).not.toContain("secret-key-material");
+  });
+
+  it("redacts sensitive fields returned in CDN error bodies", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: false,
+        status: 500,
+        statusText: "Internal Server Error",
+        text: vi.fn().mockResolvedValue('{"aes_key":"secret-key","message":"failed"}'),
+      } as unknown as Response),
+    );
+
+    let thrown = "";
+    try {
+      await downloadPlainCdnBuffer(
+        "encrypted-param",
+        "https://cdn.example",
+        "test",
+        "https://cdn.example/download?signature=secret",
+      );
+    } catch (err) {
+      thrown = String(err);
+    }
+
+    const messages = loggerMock.error.mock.calls.flat().join("\n");
+    expect(thrown).toContain("CDN download 500");
+    expect(thrown).not.toContain("secret-key");
+    expect(messages).toContain('"aes_key":"<redacted>"');
+    expect(messages).not.toContain("secret-key");
+  });
+});

--- a/src/cdn/pic-decrypt.ts
+++ b/src/cdn/pic-decrypt.ts
@@ -1,6 +1,7 @@
 import { decryptAesEcb } from "./aes-ecb.js";
 import { buildCdnDownloadUrl, ENABLE_CDN_URL_FALLBACK } from "./cdn-url.js";
 import { logger } from "../util/logger.js";
+import { redactBody, redactUrl } from "../util/redact.js";
 
 /**
  * Download raw bytes from the CDN (no decryption).
@@ -13,14 +14,14 @@ async function fetchCdnBytes(url: string, label: string): Promise<Buffer> {
     const cause =
       (err as NodeJS.ErrnoException).cause ?? (err as NodeJS.ErrnoException).code ?? "(no cause)";
     logger.error(
-      `${label}: fetch network error url=${url} err=${String(err)} cause=${String(cause)}`,
+      `${label}: fetch network error url=${redactUrl(url)} err=${String(err)} cause=${String(cause)}`,
     );
     throw err;
   }
   logger.debug(`${label}: response status=${res.status} ok=${res.ok}`);
   if (!res.ok) {
     const body = await res.text().catch(() => "(unreadable)");
-    const msg = `${label}: CDN download ${res.status} ${res.statusText} body=${body}`;
+    const msg = `${label}: CDN download ${res.status} ${res.statusText} body=${redactBody(body)}`;
     logger.error(msg);
     throw new Error(msg);
   }
@@ -46,7 +47,7 @@ function parseAesKey(aesKeyBase64: string, label: string): Buffer {
     // hex-encoded key: base64 → hex string → raw bytes
     return Buffer.from(decoded.toString("ascii"), "hex");
   }
-  const msg = `${label}: aes_key must decode to 16 raw bytes or 32-char hex string, got ${decoded.length} bytes (base64="${aesKeyBase64}")`;
+  const msg = `${label}: aes_key must decode to 16 raw bytes or 32-char hex string, got ${decoded.length} bytes (inputLen=${aesKeyBase64.length})`;
   logger.error(msg);
   throw new Error(msg);
 }
@@ -71,7 +72,7 @@ export async function downloadAndDecryptBuffer(
   } else {
     throw new Error(`${label}: fullUrl is required (CDN URL fallback is disabled)`);
   }
-  logger.debug(`${label}: fetching url=${url}`);
+  logger.debug(`${label}: fetching url=${redactUrl(url)}`);
   const encrypted = await fetchCdnBytes(url, label);
   logger.debug(`${label}: downloaded ${encrypted.byteLength} bytes, decrypting`);
   const decrypted = decryptAesEcb(encrypted, key);
@@ -96,6 +97,6 @@ export async function downloadPlainCdnBuffer(
   } else {
     throw new Error(`${label}: fullUrl is required (CDN URL fallback is disabled)`);
   }
-  logger.debug(`${label}: fetching url=${url}`);
+  logger.debug(`${label}: fetching url=${redactUrl(url)}`);
   return fetchCdnBytes(url, label);
 }

--- a/src/cdn/upload.ts
+++ b/src/cdn/upload.ts
@@ -7,7 +7,7 @@ import type { WeixinApiOptions } from "../api/api.js";
 import { aesEcbPaddedSize } from "./aes-ecb.js";
 import { uploadBufferToCdn } from "./cdn-upload.js";
 import { logger } from "../util/logger.js";
-import { redactUrl } from "../util/redact.js";
+import { redactBody, redactUrl } from "../util/redact.js";
 import { getExtensionFromContentTypeOrUrl } from "../media/mime.js";
 import { tempFileName } from "../util/random.js";
 import { UploadMediaType } from "../api/types.js";
@@ -97,7 +97,7 @@ async function uploadMediaToCdn(params: {
   const uploadParam = uploadUrlResp.upload_param;
   if (!uploadFullUrl && !uploadParam) {
     logger.error(
-      `${label}: getUploadUrl returned no upload URL (need upload_full_url or upload_param), resp=${JSON.stringify(uploadUrlResp)}`,
+      `${label}: getUploadUrl returned no upload URL (need upload_full_url or upload_param), resp=${redactBody(JSON.stringify(uploadUrlResp))}`,
     );
     throw new Error(`${label}: getUploadUrl returned no upload URL`);
   }

--- a/src/compat.test.ts
+++ b/src/compat.test.ts
@@ -22,6 +22,9 @@ describe("parseOpenClawVersion", () => {
     expect(parseOpenClawVersion("abc")).toBeNull();
     expect(parseOpenClawVersion("2026.3")).toBeNull();
     expect(parseOpenClawVersion("2026.3.22.1")).toBeNull();
+    expect(parseOpenClawVersion("invalid.3.22")).toBeNull();
+    expect(parseOpenClawVersion("2026.invalid.22")).toBeNull();
+    expect(parseOpenClawVersion("2026.3.invalid")).toBeNull();
   });
 });
 

--- a/src/media/media-download.ts
+++ b/src/media/media-download.ts
@@ -44,7 +44,7 @@ export async function downloadMediaFromItem(
       ? Buffer.from(img.aeskey, "hex").toString("base64")
       : img.media.aes_key;
     logger.debug(
-      `${label} image: encrypt_query_param=${(img.media.encrypt_query_param ?? "").slice(0, 40)}... hasAesKey=${Boolean(aesKeyBase64)} aeskeySource=${img.aeskey ? "image_item.aeskey" : "media.aes_key"} full_url=${Boolean(img.media.full_url)}`,
+      `${label} image: hasEncryptQueryParam=${Boolean(img.media.encrypt_query_param)} hasAesKey=${Boolean(aesKeyBase64)} aeskeySource=${img.aeskey ? "image_item.aeskey" : "media.aes_key"} full_url=${Boolean(img.media.full_url)}`,
     );
     try {
       const buf = aesKeyBase64

--- a/src/messaging/error-notice.test.ts
+++ b/src/messaging/error-notice.test.ts
@@ -54,6 +54,29 @@ describe("sendWeixinErrorNotice", () => {
     expect(mockSendMessageWeixin).toHaveBeenCalledOnce();
   });
 
+  it("forwards runId when provided", async () => {
+    mockSendMessageWeixin.mockResolvedValueOnce({ messageId: "m3" });
+    await sendWeixinErrorNotice({
+      to: "user1",
+      contextToken: "ctx",
+      message: "err",
+      baseUrl: "https://api.com",
+      runId: "run-1",
+      errLog: vi.fn(),
+    });
+
+    expect(mockSendMessageWeixin).toHaveBeenCalledWith({
+      to: "user1",
+      text: "err",
+      opts: {
+        baseUrl: "https://api.com",
+        token: undefined,
+        contextToken: "ctx",
+        runId: "run-1",
+      },
+    });
+  });
+
   it("catches and logs errors from sendMessageWeixin", async () => {
     mockSendMessageWeixin.mockRejectedValueOnce(new Error("send failed"));
     const errLog = vi.fn();

--- a/src/util/redact.test.ts
+++ b/src/util/redact.test.ts
@@ -76,6 +76,43 @@ describe("redactBody", () => {
     const body = '{"token":"my-secret-token"}';
     expect(redactBody(body)).toBe('{"token":"<redacted>"}');
   });
+
+  it("redacts nested credential and CDN fields", () => {
+    const body = JSON.stringify({
+      status: "confirmed",
+      result: {
+        aes_key: "base64-secret",
+        encrypt_query_param: "signed-download-param",
+        upload_full_url: "https://cdn.example/upload?signature=secret",
+      },
+    });
+
+    const redacted = redactBody(body);
+    expect(redacted).toContain('"status":"confirmed"');
+    expect(redacted).not.toContain("base64-secret");
+    expect(redacted).not.toContain("signed-download-param");
+    expect(redacted).not.toContain("signature=secret");
+  });
+
+  it("redacts arrays stored in sensitive fields", () => {
+    const body = '{"local_token_list":["token-a","token-b"],"count":2}';
+    expect(redactBody(body)).toBe('{"local_token_list":"<redacted>","count":2}');
+  });
+
+  it("redacts sensitive fields case-insensitively", () => {
+    expect(redactBody('{"Authorization":"Bearer secret"}')).toBe(
+      '{"Authorization":"<redacted>"}',
+    );
+  });
+
+  it("redacts sensitive values in malformed JSON as a fallback", () => {
+    const body = 'partial:{"bot_token":"secret","local_token_list":["a","b"]';
+    const redacted = redactBody(body);
+    expect(redacted).not.toContain("secret");
+    expect(redacted).not.toContain('"a"');
+    expect(redacted).toContain('"bot_token":"<redacted>"');
+    expect(redacted).toContain('"local_token_list":"<redacted>"');
+  });
 });
 
 describe("redactUrl", () => {

--- a/src/util/redact.ts
+++ b/src/util/redact.ts
@@ -22,7 +22,46 @@ export function redactToken(token: string | undefined, prefixLen = DEFAULT_TOKEN
 }
 
 /** Field names whose values should be masked in logged JSON bodies. */
-const SENSITIVE_FIELDS = /\b(context_token|bot_token|token|authorization|Authorization)\b/;
+const SENSITIVE_FIELD_NAMES = [
+  "authorization",
+  "token",
+  "bot_token",
+  "context_token",
+  "local_token_list",
+  "aeskey",
+  "aes_key",
+  "encrypt_query_param",
+  "upload_param",
+  "thumb_upload_param",
+  "upload_full_url",
+  "full_url",
+  "qrcode",
+  "qrcode_url",
+  "verify_code",
+] as const;
+
+const SENSITIVE_FIELDS = new Set<string>(SENSITIVE_FIELD_NAMES);
+const SENSITIVE_FIELD_PATTERN = SENSITIVE_FIELD_NAMES.join("|");
+const SENSITIVE_STRING_FIELD_RE = new RegExp(
+  `"(${SENSITIVE_FIELD_PATTERN})"\\s*:\\s*"(?:\\\\.|[^"\\\\])*"`,
+  "gi",
+);
+const SENSITIVE_COMPOSITE_FIELD_RE = new RegExp(
+  `"(${SENSITIVE_FIELD_PATTERN})"\\s*:\\s*(?:\\[[^\\]]*\\]|\\{[^}]*\\})`,
+  "gi",
+);
+
+function redactJsonValue(value: unknown): unknown {
+  if (Array.isArray(value)) return value.map(redactJsonValue);
+  if (value === null || typeof value !== "object") return value;
+
+  return Object.fromEntries(
+    Object.entries(value).map(([key, child]) => [
+      key,
+      SENSITIVE_FIELDS.has(key.toLowerCase()) ? "<redacted>" : redactJsonValue(child),
+    ]),
+  );
+}
 
 /**
  * Truncate a JSON body string to `maxLen` chars for safe logging.
@@ -30,11 +69,15 @@ const SENSITIVE_FIELDS = /\b(context_token|bot_token|token|authorization|Authori
  */
 export function redactBody(body: string | undefined, maxLen = DEFAULT_BODY_MAX_LEN): string {
   if (!body) return "(empty)";
-  // Mask values of known sensitive JSON keys: "key":"value" → "key":"<redacted>"
-  const redacted = body.replace(
-    /"(context_token|bot_token|token|authorization|Authorization)"\s*:\s*"[^"]*"/g,
-    '"$1":"<redacted>"',
-  );
+  let redacted: string;
+  try {
+    redacted = JSON.stringify(redactJsonValue(JSON.parse(body)));
+  } catch {
+    // Best-effort fallback for malformed or partial JSON returned by an upstream service.
+    redacted = body
+      .replace(SENSITIVE_STRING_FIELD_RE, '"$1":"<redacted>"')
+      .replace(SENSITIVE_COMPOSITE_FIELD_RE, '"$1":"<redacted>"');
+  }
   if (redacted.length <= maxLen) return redacted;
   return `${redacted.slice(0, maxLen)}…(truncated, totalLen=${redacted.length})`;
 }


### PR DESCRIPTION
## Summary

- recursively redact sensitive credential and CDN fields in JSON bodies, including nested objects and token arrays
- redact QR status responses, signed CDN URLs, CDN error bodies, and malformed AES key diagnostics
- avoid logging partial encrypted query parameters and sanitize non-success HTTP response errors
- add regression tests for structured, malformed, and CDN-related sensitive data, plus close existing branch-coverage gaps

## Verification

- `npm test -- --reporter=dot` — 408 tests passed, branch coverage 90.12%
- `npm run typecheck`
- `npm run build`
- `git diff --check`