### PR TITLE
fix: align runtime host check with OpenClaw >=2026.5.12

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,8 +8,8 @@ OpenClaw's WeChat channel plugin, supporting login authorization via QR code sca
 
 | Plugin Version | OpenClaw Version       | npm dist-tag | Status      |
 |---------------|------------------------|--------------|-------------|
-| 2.0.x         | >=2026.3.22            | `latest`     | Active      |
-| 1.0.x         | >=2026.1.0 <2026.3.22  | `legacy`     | Maintenance |
+| 2.x           | >=2026.5.12            | `latest`     | Active      |
+| 1.x           | >=2026.1.0 <2026.3.22  | `legacy`     | Maintenance |
 
 > The plugin checks the host version at startup and will refuse to load if the
 > running OpenClaw version is outside the supported range.
@@ -327,7 +327,7 @@ openclaw plugins uninstall @tencent-weixin/openclaw-weixin
 
 ## Troubleshooting
 
-### "requires OpenClaw >=2026.3.22" error
+### "requires OpenClaw >=2026.5.12" error
 
 Your OpenClaw version is too old for this plugin version. Check with:
 

--- a/README.zh_CN.md
+++ b/README.zh_CN.md
@@ -8,8 +8,8 @@ OpenClaw 的微信渠道插件，支持通过扫码完成登录授权。
 
 | 插件版本 | OpenClaw 版本            | npm dist-tag | 状态   |
 |---------|--------------------------|--------------|--------|
-| 2.0.x   | >=2026.3.22              | `latest`     | 活跃   |
-| 1.0.x   | >=2026.1.0 <2026.3.22    | `legacy`     | 维护中 |
+| 2.x     | >=2026.5.12              | `latest`     | 活跃   |
+| 1.x     | >=2026.1.0 <2026.3.22    | `legacy`     | 维护中 |
 
 > 插件在启动时会检查宿主版本，如果运行的 OpenClaw 版本超出支持范围，插件将拒绝加载。
 
@@ -323,7 +323,7 @@ openclaw plugins uninstall @tencent-weixin/openclaw-weixin
 
 ## 故障排查
 
-### "requires OpenClaw >=2026.3.22" 报错
+### "requires OpenClaw >=2026.5.12" 报错
 
 你的 OpenClaw 版本太旧，不兼容当前插件版本。检查版本：
 

--- a/src/channel.ts
+++ b/src/channel.ts
@@ -445,7 +445,7 @@ export const weixinPlugin: ChannelPlugin<ResolvedWeixinAccount> = {
 
       // The gateway injects the channel runtime surface per-call (task-scoped). We require it:
       // it carries reply/routing/session/media/commands helpers used by processOneMessage.
-      // Available on hosts >= 2026.2.19 (our peerDependency is >= 2026.3.22).
+      // Available on hosts >= 2026.2.19 (our peerDependency is >= 2026.5.12).
       if (!ctx.channelRuntime) {
         const msg = `ctx.channelRuntime missing — host too old or plugin SDK contract violated`;
         aLog.error(msg);

--- a/src/compat.test.ts
+++ b/src/compat.test.ts
@@ -46,15 +46,15 @@ describe("isHostVersionSupported", () => {
   });
 
   it("rejects the day before the minimum", () => {
-    expect(isHostVersionSupported("2026.3.21")).toBe(false);
+    expect(isHostVersionSupported("2026.5.11")).toBe(false);
   });
 
   it("accepts a version above the minimum", () => {
-    expect(isHostVersionSupported("2026.3.30")).toBe(true);
+    expect(isHostVersionSupported("2026.5.13")).toBe(true);
   });
 
   it("accepts a future version", () => {
-    expect(isHostVersionSupported("2026.4.0")).toBe(true);
+    expect(isHostVersionSupported("2026.6.0")).toBe(true);
     expect(isHostVersionSupported("2027.1.1")).toBe(true);
   });
 
@@ -65,7 +65,7 @@ describe("isHostVersionSupported", () => {
 
 describe("assertHostCompatibility", () => {
   it("does not throw for a supported version", () => {
-    expect(() => assertHostCompatibility("2026.3.22")).not.toThrow();
+    expect(() => assertHostCompatibility("2026.5.12")).not.toThrow();
   });
 
   it("does not throw when version is undefined (graceful skip)", () => {

--- a/src/compat.ts
+++ b/src/compat.ts
@@ -8,7 +8,7 @@
 
 import { logger } from "./util/logger.js";
 
-export const SUPPORTED_HOST_MIN = "2026.3.22";
+export const SUPPORTED_HOST_MIN = "2026.5.12";
 
 export interface OpenClawVersion {
   year: number;


### PR DESCRIPTION
## Summary

- `package.json` already requires OpenClaw `>=2026.5.12` (`peerDependencies.openclaw` and `openclaw.install.minHostVersion`). Changelog 2.4.5 records that bump from `>=2026.3.22`.
- The runtime guard (`SUPPORTED_HOST_MIN` in `src/compat.ts`) and both READMEs were still advertising `>=2026.3.22`.
- Hosts on `2026.3.22`–`2026.5.11` could therefore load the plugin and then fail on the newer `ctx.channelRuntime` contract, instead of getting the intended clear version error.

This syncs the fail-fast check, tests, and EN/ZH docs with the published requirement. Official channel docs already describe 2.x as `>=2026.5.12`: https://docs.openclaw.ai/channels/wechat

## Test plan

- [x] `SUPPORTED_HOST_MIN` matches `package.json` (`>=2026.5.12`)
- [x] Compat tests updated for the new floor (accept `2026.5.12` / `2026.5.13`, reject `2026.5.11`)
- [ ] `npx vitest run src/compat.test.ts` on the PR CI
- [ ] Confirm troubleshooting heading matches the error string thrown by `assertHostCompatibility`