### PR TITLE
fix(messaging): rewrite bare < so WeChat does not swallow the line

### DIFF
--- a/src/messaging/markdown-filter.test.ts
+++ b/src/messaging/markdown-filter.test.ts
@@ -699,6 +699,8 @@ describe("StreamingMarkdownFilter", () => {
       ["##### H5 heading", "H5 heading"],
       ["## H2 heading", "## H2 heading"],
       ["before\n---\nafter", "before\n---\nafter"],
+      ["rate<80% **ok**", "rate\uFF1C80% **ok**"],
+      ["see <div>x</div>", "see <div>x</div>"],
       [
         "Here **bold** and *italic* `code` ~~strike~~ ***bi*** end",
         "Here **bold** and *italic* `code` ~~strike~~ ***bi*** end",
@@ -725,6 +727,60 @@ describe("StreamingMarkdownFilter", () => {
       const f = new StreamingMarkdownFilter();
       const out = f.feed("  - nested") + f.flush();
       expect(out).toBe("  - nested");
+    });
+  });
+
+  // ---- Bare < vs HTML tags (WeChat renderer) --------------------------------
+
+  describe("bare less-than vs HTML tags", () => {
+    const FW = "\uFF1C";
+
+    it("rewrites comparison <80% so WeChat does not swallow the line", () => {
+      expectFilter(
+        "当CPU使用率<80%时属于**正常范围**",
+        "当CPU使用率" + FW + "80%时属于**正常范围**",
+      );
+    });
+
+    it("rewrites <50mg next to bold", () => {
+      expectFilter(
+        "推荐摄入量<50mg属于**安全剂量**",
+        "推荐摄入量" + FW + "50mg属于**安全剂量**",
+      );
+    });
+
+    it("leaves bold unchanged when there is no <", () => {
+      expectFilter("这是**正常加粗**测试", "这是**正常加粗**测试");
+    });
+
+    it("rewrites a trailing bare < at EOF", () => {
+      expectFilter("value<", "value" + FW);
+    });
+
+    it("passes through a real HTML start tag", () => {
+      expectFilter("see <div>ok</div>", "see <div>ok</div>");
+    });
+
+    it("passes through a closing tag", () => {
+      expectFilter("end</span> after", "end</span> after");
+    });
+
+    it("leaves < inside a code fence unchanged", () => {
+      expect(oneShot("```\nif (x < 80) {}\n```\n")).toBe("```\nif (x < 80) {}\n```\n");
+    });
+
+    it("holds a split < until the next character arrives", () => {
+      const f = new StreamingMarkdownFilter();
+      const a = f.feed("rate<");
+      expect(a).toBe("rate");
+      const b = f.feed("80%") + f.flush();
+      expect(b).toBe(FW + "80%");
+    });
+
+    it("holds a split < that becomes a real tag", () => {
+      const f = new StreamingMarkdownFilter();
+      expect(f.feed("see <")).toBe("see ");
+      expect(f.feed("br>") + f.flush()).toBe("<br>");
     });
   });
 

--- a/src/messaging/markdown-filter.ts
+++ b/src/messaging/markdown-filter.ts
@@ -13,6 +13,7 @@
  * - Horizontal rules (---, ***, ___)
  * - Bold (**)
  * - Italic/bold-italic wrapping non-CJK content
+ * - Real HTML tags (<div>, </span>); bare "<" becomes full-width U+FF1C
  *
  * Constructs filtered (markers stripped, content kept):
  * - Italic/bold-italic wrapping CJK content
@@ -202,6 +203,29 @@ export class StreamingMarkdownFilter {
         i++;
         continue;
       }
+      if (c === "<") {
+        // WeChat treats any "<" as an HTML tag start and swallows the rest
+        // of the line (also breaking **bold**). Only real tags start with
+        // a letter or "/"; other bare "<" become full-width U+FF1C.
+        if (i + 1 >= this.buf.length) {
+          if (!eof) {
+            out += this.buf.slice(0, i);
+            this.buf = this.buf.slice(i);
+            return out;
+          }
+          out += this.buf.slice(0, i) + "\uFF1C";
+          this.buf = this.buf.slice(i + 1);
+          return out;
+        }
+        const next = this.buf[i + 1];
+        if (/[a-zA-Z/]/.test(next)) {
+          i++;
+          continue;
+        }
+        out += this.buf.slice(0, i) + "\uFF1C";
+        this.buf = this.buf.slice(i + 1);
+        return out;
+      }
       if (c === "*") {
         if (i + 2 < this.buf.length && this.buf[i + 1] === "*" && this.buf[i + 2] === "*") {
           out += this.buf.slice(0, i);
@@ -252,6 +276,7 @@ export class StreamingMarkdownFilter {
       else if (this.buf.endsWith("*")) hold = 1;
       else if (this.buf.endsWith("_")) hold = 1;
       else if (this.buf.endsWith("!")) hold = 1;
+      else if (this.buf.endsWith("<")) hold = 1;
     }
     out += this.buf.slice(0, this.buf.length - hold);
     this.buf = hold > 0 ? this.buf.slice(-hold) : "";


### PR DESCRIPTION
Fixes #245. WeChat treats any < as an HTML tag start, so comparisons like <80% hide the rest of the line and break **bold**. HTML entities display literally, so non-tag < is rewritten to full-width U+FF1C. Real tags (<div>, </span>) and code-fence content are unchanged. 146 markdown-filter tests pass, including the issue reproductions and streaming hold-back for a split <.