### PR TITLE
fix: import typing callbacks from compatible SDK path

### DIFF
--- a/src/messaging/process-message.ts
+++ b/src/messaging/process-message.ts
@@ -1,7 +1,7 @@
 import path from "node:path";
 import { randomUUID } from "node:crypto";
 
-import { createTypingCallbacks } from "openclaw/plugin-sdk/channel-runtime";
+import { createTypingCallbacks } from "openclaw/plugin-sdk/channel-reply-pipeline";
 import {
   resolveSenderCommandAuthorizationWithRuntime,
   resolveDirectDmAuthorizationOutcome,


### PR DESCRIPTION
## Summary

- import `createTypingCallbacks` from `openclaw/plugin-sdk/channel-reply-pipeline`
- preserve compatibility with the declared minimum host (`openclaw >=2026.5.12`)
- restore compatibility with current hosts that no longer export `plugin-sdk/channel-runtime`

## Problem

`@tencent-weixin/openclaw-weixin@2.4.6` currently imports `createTypingCallbacks` from `openclaw/plugin-sdk/channel-runtime`. OpenClaw removed that package export in `2026.7.2-beta.4`, so the Weixin provider exits at startup on newer hosts with:

```text
Package subpath './plugin-sdk/channel-runtime' is not defined by "exports"
```

This was reproduced with OpenClaw `2026.8.1-beta.2`: the channel repeatedly restarted and never received messages.

`channel-reply-pipeline` is exported by both the plugin's minimum supported host (`2026.5.12`) and `2026.8.1-beta.2`, and exports the same `createTypingCallbacks` helper. `channel-outbound` would be canonical on current hosts, but is not exported by `2026.5.12`, so using it would break the existing compatibility contract.

Related OpenClaw report: https://github.com/openclaw/openclaw/issues/115478

## Verification

- `npm run typecheck` against `openclaw@2026.5.12`
- `npm run build`
- verified `createTypingCallbacks` resolves from `channel-reply-pipeline` on `openclaw@2026.8.1-beta.2`
- all 397 Vitest cases pass; the repository's coverage command still exits non-zero because branch coverage is 89.13% against the configured 90% threshold (`process-message.ts` is excluded from coverage)
