### PR TITLE
fix: expose exact outbound session routes

### DIFF
--- a/src/channel.test.ts
+++ b/src/channel.test.ts
@@ -1,0 +1,60 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { registerWeixinAccountId } from "./auth/accounts.js";
+import { weixinPlugin } from "./channel.js";
+
+let stateDir: string;
+
+beforeEach(() => {
+  stateDir = fs.mkdtempSync(path.join(os.tmpdir(), "weixin-session-route-"));
+  process.env.OPENCLAW_STATE_DIR = stateDir;
+});
+
+afterEach(() => {
+  delete process.env.OPENCLAW_STATE_DIR;
+  fs.rmSync(stateDir, { recursive: true, force: true });
+});
+
+async function resolveRoute(params: { target: string; accountId?: string }) {
+  const resolver = weixinPlugin.messaging?.resolveOutboundSessionRoute;
+  if (!resolver) throw new Error("expected outbound session route resolver");
+  return await resolver({
+    cfg: { session: { dmScope: "per-account-channel-peer" } },
+    agentId: "main",
+    target: params.target,
+    accountId: params.accountId,
+  });
+}
+
+describe("Weixin outbound session route", () => {
+  it("certifies an explicit account and canonical Weixin user", async () => {
+    const route = await resolveRoute({
+      target: "openclaw-weixin:user:Alice@im.wechat",
+      accountId: "Bot@One",
+    });
+
+    expect(route).toMatchObject({
+      sessionKey: "agent:main:openclaw-weixin:bot-one:direct:alice@im.wechat",
+      recipientSessionExact: true,
+      peer: { kind: "direct", id: "Alice@im.wechat" },
+      to: "Alice@im.wechat",
+    });
+  });
+
+  it("uses the only registered account instead of the default account", async () => {
+    registerWeixinAccountId("bot-one");
+
+    const route = await resolveRoute({ target: "alice@im.wechat" });
+
+    expect(route).toMatchObject({
+      sessionKey: "agent:main:openclaw-weixin:bot-one:direct:alice@im.wechat",
+      recipientSessionExact: true,
+    });
+  });
+
+  it("rejects targets that cannot identify an inbound Weixin session", async () => {
+    await expect(resolveRoute({ target: "group:alice@im.wechat" })).resolves.toBeNull();
+  });
+});

--- a/src/channel.ts
+++ b/src/channel.ts
@@ -1,6 +1,14 @@
 import path from "node:path";
 
-import type { ChannelPlugin, OpenClawConfig, PluginRuntime } from "openclaw/plugin-sdk/core";
+import {
+  buildChannelOutboundSessionRoute,
+  stripChannelTargetPrefix,
+  stripTargetKindPrefix,
+  type ChannelOutboundSessionRouteParams,
+  type ChannelPlugin,
+  type OpenClawConfig,
+  type PluginRuntime,
+} from "openclaw/plugin-sdk/core";
 import { normalizeAccountId } from "openclaw/plugin-sdk/account-id";
 import { resolvePreferredOpenClawTmpDir } from "openclaw/plugin-sdk/infra-runtime";
 
@@ -106,6 +114,34 @@ function resolveOutboundAccountId(
   );
 }
 
+function normalizeWeixinUserId(raw: string): string | null {
+  const channelTarget = stripChannelTargetPrefix(raw.trim(), "openclaw-weixin");
+  const userId = stripTargetKindPrefix(channelTarget).trim();
+  if (userId !== channelTarget.trim() && !/^(user|dm):/i.test(channelTarget)) return null;
+  return userId.endsWith("@im.wechat") ? userId : null;
+}
+
+function resolveWeixinOutboundSessionRoute(params: ChannelOutboundSessionRouteParams) {
+  const userId = normalizeWeixinUserId(params.target);
+  if (!userId) return null;
+  const accountId = params.accountId?.trim()
+    ? resolveWeixinAccount(params.cfg, params.accountId).accountId
+    : resolveOutboundAccountId(params.cfg, userId);
+  return {
+    ...buildChannelOutboundSessionRoute({
+      cfg: params.cfg,
+      agentId: params.agentId,
+      channel: "openclaw-weixin",
+      accountId,
+      peer: { kind: "direct", id: userId },
+      chatType: "direct",
+      from: userId,
+      to: userId,
+    }),
+    recipientSessionExact: true as const,
+  };
+}
+
 async function sendWeixinOutbound(params: {
   cfg: OpenClawConfig;
   to: string;
@@ -190,8 +226,9 @@ export const weixinPlugin: ChannelPlugin<ResolvedWeixinAccount> = {
   messaging: {
     targetResolver: {
       // Weixin user IDs always end with @im.wechat; treat as direct IDs, skip directory lookup.
-      looksLikeId: (raw) => raw.endsWith("@im.wechat"),
+      looksLikeId: (raw) => normalizeWeixinUserId(raw) !== null,
     },
+    resolveOutboundSessionRoute: resolveWeixinOutboundSessionRoute,
   },
   agentPrompt: {
     messageToolHints: () => [


### PR DESCRIPTION
## Summary

- expose an exact outbound session route for canonical direct Weixin recipients
- resolve the real outbound account before constructing the session key
- reject non-direct target prefixes instead of claiming an exact route

This is the plugin-side companion to openclaw/openclaw#130871. That core change projects delivered heartbeat results only when a channel plugin certifies that the outbound recipient maps exactly to the canonical inbound session. The core also downgrades this certification when a binding belongs to another agent.

## Validation

- `npm run typecheck`
- `npm run build`
- `npx vitest run src/channel.test.ts` — 3/3 passed
- full `npm test` — all 400 tests passed; the command exits non-zero only because the repository-wide pre-existing branch-coverage result is 89.15% against a 90% threshold. Excluding the new test still reports 89.13%, so this patch does not introduce the baseline gap.

No merge is requested until the corresponding generic OpenClaw host contract is accepted.