### PR TITLE
refactor: remove unused pairing store writer and deprecated lock dependency

### DIFF
--- a/src/auth/pairing.test.ts
+++ b/src/auth/pairing.test.ts
@@ -3,23 +3,6 @@ import fs from "node:fs";
 import path from "node:path";
 import os from "node:os";
 
-vi.mock("../util/logger.js", () => ({
-  logger: {
-    info: vi.fn(),
-    debug: vi.fn(),
-    warn: vi.fn(),
-    error: vi.fn(),
-  },
-}));
-
-const mockWithFileLock = vi.hoisted(() =>
-  vi.fn(async (_path: string, _opts: unknown, fn: () => Promise<unknown>) => fn()),
-);
-
-vi.mock("openclaw/plugin-sdk/infra-runtime", () => ({
-  withFileLock: mockWithFileLock,
-}));
-
 let tmpDir: string;
 
 beforeEach(() => {
@@ -63,114 +46,30 @@ describe("resolveFrameworkAllowFromPath", () => {
   });
 });
 
-describe("registerUserInFrameworkStore", () => {
-  it("creates file and adds userId when file does not exist", async () => {
-    const { registerUserInFrameworkStore, resolveFrameworkAllowFromPath } =
-      await loadModule();
-    const result = await registerUserInFrameworkStore({
-      accountId: "acc1",
-      userId: "user-abc",
-    });
-    expect(result.changed).toBe(true);
-
-    const filePath = resolveFrameworkAllowFromPath("acc1");
-    const content = JSON.parse(fs.readFileSync(filePath, "utf-8"));
-    expect(content).toEqual({ version: 1, allowFrom: ["user-abc"] });
-  });
-
-  it("appends userId to existing allowFrom list", async () => {
-    const { registerUserInFrameworkStore, resolveFrameworkAllowFromPath } =
-      await loadModule();
-    const filePath = resolveFrameworkAllowFromPath("acc2");
+describe("readFrameworkAllowFromList", () => {
+  it("reads existing paired IDs without rewriting the credentials file", async () => {
+    const { readFrameworkAllowFromList, resolveFrameworkAllowFromPath } = await loadModule();
+    const filePath = resolveFrameworkAllowFromPath("existing-account");
     fs.mkdirSync(path.dirname(filePath), { recursive: true });
-    fs.writeFileSync(
-      filePath,
-      JSON.stringify({ version: 1, allowFrom: ["existing-user"] }),
-      "utf-8",
-    );
+    const saved = JSON.stringify({ version: 1, allowFrom: ["owner", "second-user", "", 42] });
+    fs.writeFileSync(filePath, saved);
 
-    const result = await registerUserInFrameworkStore({
-      accountId: "acc2",
-      userId: "new-user",
-    });
-    expect(result.changed).toBe(true);
-
-    const content = JSON.parse(fs.readFileSync(filePath, "utf-8"));
-    expect(content.allowFrom).toEqual(["existing-user", "new-user"]);
+    expect(readFrameworkAllowFromList("existing-account")).toEqual(["owner", "second-user"]);
+    expect(fs.readFileSync(filePath, "utf-8")).toBe(saved);
   });
 
-  it("returns changed=false when userId already exists", async () => {
-    const { registerUserInFrameworkStore, resolveFrameworkAllowFromPath } =
-      await loadModule();
-    const filePath = resolveFrameworkAllowFromPath("acc3");
+  it("returns an empty list without creating a missing credentials file", async () => {
+    const { readFrameworkAllowFromList, resolveFrameworkAllowFromPath } = await loadModule();
+    expect(readFrameworkAllowFromList("missing-account")).toEqual([]);
+    expect(fs.existsSync(resolveFrameworkAllowFromPath("missing-account"))).toBe(false);
+  });
+
+  it("leaves an unreadable credentials file untouched", async () => {
+    const { readFrameworkAllowFromList, resolveFrameworkAllowFromPath } = await loadModule();
+    const filePath = resolveFrameworkAllowFromPath("corrupt-account");
     fs.mkdirSync(path.dirname(filePath), { recursive: true });
-    fs.writeFileSync(
-      filePath,
-      JSON.stringify({ version: 1, allowFrom: ["user-abc"] }),
-      "utf-8",
-    );
-
-    const result = await registerUserInFrameworkStore({
-      accountId: "acc3",
-      userId: "user-abc",
-    });
-    expect(result.changed).toBe(false);
-
-    const content = JSON.parse(fs.readFileSync(filePath, "utf-8"));
-    expect(content.allowFrom).toEqual(["user-abc"]);
-  });
-
-  it("returns changed=false for empty userId", async () => {
-    const { registerUserInFrameworkStore } = await loadModule();
-    const result = await registerUserInFrameworkStore({
-      accountId: "acc4",
-      userId: "  ",
-    });
-    expect(result.changed).toBe(false);
-  });
-
-  it("trims userId before storing", async () => {
-    const { registerUserInFrameworkStore, resolveFrameworkAllowFromPath } =
-      await loadModule();
-    await registerUserInFrameworkStore({
-      accountId: "acc5",
-      userId: "  user-trimmed  ",
-    });
-
-    const filePath = resolveFrameworkAllowFromPath("acc5");
-    const content = JSON.parse(fs.readFileSync(filePath, "utf-8"));
-    expect(content.allowFrom).toEqual(["user-trimmed"]);
-  });
-
-  it("uses withFileLock for concurrency safety", async () => {
-    mockWithFileLock.mockClear();
-    const { registerUserInFrameworkStore } = await loadModule();
-    await registerUserInFrameworkStore({
-      accountId: "acc6",
-      userId: "user-lock",
-    });
-
-    expect(mockWithFileLock).toHaveBeenCalledTimes(1);
-    const [lockPath, lockOpts] = mockWithFileLock.mock.calls[0]!;
-    expect(lockPath).toContain("openclaw-weixin-acc6-allowFrom.json");
-    expect(lockOpts).toHaveProperty("retries");
-    expect(lockOpts).toHaveProperty("stale");
-  });
-
-  it("handles corrupted file gracefully", async () => {
-    const { registerUserInFrameworkStore, resolveFrameworkAllowFromPath } =
-      await loadModule();
-    const filePath = resolveFrameworkAllowFromPath("acc7");
-    fs.mkdirSync(path.dirname(filePath), { recursive: true });
-    fs.writeFileSync(filePath, "not-valid-json{{{", "utf-8");
-
-    const result = await registerUserInFrameworkStore({
-      accountId: "acc7",
-      userId: "user-recover",
-    });
-    expect(result.changed).toBe(true);
-
-    const content = JSON.parse(fs.readFileSync(filePath, "utf-8"));
-    expect(content.allowFrom).toEqual(["user-recover"]);
+    fs.writeFileSync(filePath, "not valid json");
+    expect(readFrameworkAllowFromList("corrupt-account")).toEqual([]);
+    expect(fs.readFileSync(filePath, "utf-8")).toBe("not valid json");
   });
 });

--- a/src/auth/pairing.ts
+++ b/src/auth/pairing.ts
@@ -1,10 +1,7 @@
 import fs from "node:fs";
 import path from "node:path";
 
-import { withFileLock } from "openclaw/plugin-sdk/infra-runtime";
-
 import { resolveStateDir } from "../storage/state-dir.js";
-import { logger } from "../util/logger.js";
 
 /**
  * Resolve the framework credentials directory (mirrors core resolveOAuthDir).
@@ -60,61 +57,4 @@ export function readFrameworkAllowFromList(accountId: string): string[] {
     // best-effort
   }
   return [];
-}
-
-/** File lock options matching the framework's pairing store lock settings. */
-const LOCK_OPTIONS = {
-  retries: { retries: 3, factor: 2, minTimeout: 100, maxTimeout: 2000 },
-  stale: 10_000,
-};
-
-/**
- * Register a user ID in the framework's channel allowFrom store.
- * This writes directly to the same JSON file that `readChannelAllowFromStore` reads,
- * making the user visible to the framework authorization pipeline.
- *
- * Uses file locking to avoid races with concurrent readers/writers.
- */
-export async function registerUserInFrameworkStore(params: {
-  accountId: string;
-  userId: string;
-}): Promise<{ changed: boolean }> {
-  const { accountId, userId } = params;
-  const trimmedUserId = userId.trim();
-  if (!trimmedUserId) return { changed: false };
-
-  const filePath = resolveFrameworkAllowFromPath(accountId);
-
-  const dir = path.dirname(filePath);
-  fs.mkdirSync(dir, { recursive: true });
-
-  // Ensure the file exists before locking
-  if (!fs.existsSync(filePath)) {
-    const initial: AllowFromFileContent = { version: 1, allowFrom: [] };
-    fs.writeFileSync(filePath, JSON.stringify(initial, null, 2), "utf-8");
-  }
-
-  return await withFileLock(filePath, LOCK_OPTIONS, async () => {
-    let content: AllowFromFileContent = { version: 1, allowFrom: [] };
-    try {
-      const raw = fs.readFileSync(filePath, "utf-8");
-      const parsed = JSON.parse(raw) as AllowFromFileContent;
-      if (Array.isArray(parsed.allowFrom)) {
-        content = parsed;
-      }
-    } catch {
-      // If read/parse fails, start fresh
-    }
-
-    if (content.allowFrom.includes(trimmedUserId)) {
-      return { changed: false };
-    }
-
-    content.allowFrom.push(trimmedUserId);
-    fs.writeFileSync(filePath, JSON.stringify(content, null, 2), "utf-8");
-    logger.info(
-      `registerUserInFrameworkStore: added userId=${trimmedUserId} accountId=${accountId} path=${filePath}`,
-    );
-    return { changed: true };
-  });
 }


### PR DESCRIPTION
`registerUserInFrameworkStore` has no production callers in this repository or the published 2.4.6 package. It is the only consumer of the deprecated `infra-runtime` file-lock API. Remove that unused writer and its lock dependency instead of replacing it with a private SDK facade.

Keep the existing allowlist reader and path resolver: message authorization still reads existing paired IDs, and account cleanup still owns deletion. This change does not write, delete, migrate, or change the precedence of stored authorization data. Replace writer-only tests with reader coverage for existing, missing, and malformed files, including assertions that reads leave the files untouched.

Independent follow-up to #251. No host minimum or dependency changes. This removes the file-lock dependency only; the authorization API migration remains separate because it must preserve sender admission and command authorization independently.

Validation at `d16f6e4`: secretless Linux AWS proof with Node 24.19.0, the declared OpenClaw 2026.5.12 dependency, and install lifecycle scripts disabled. Typecheck, build, and all 393 tests passed; the six focused pairing tests also passed. The repository-wide coverage gate still fails: candidate branch coverage is 89.08% against 90%, while the unchanged parent also fails at 89.13% using the same dependency installation. No threshold or exclusion was weakened. Codex review and whitespace checks passed. No live Weixin session was used, and this change does not claim the separate authorization/storage migration is complete.
