### PR TITLE
docs: reorganize READMEs and extract backend protocol reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,38 +1,47 @@
-# WeChat
+# OpenClaw Weixin Channel
 
 [![CI](https://github.com/Tencent/openclaw-weixin/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/Tencent/openclaw-weixin/actions/workflows/ci.yml)
+[![npm](https://img.shields.io/npm/v/@tencent-weixin/openclaw-weixin)](https://www.npmjs.com/package/@tencent-weixin/openclaw-weixin)
+[![Node.js](https://img.shields.io/node/v/@tencent-weixin/openclaw-weixin)](https://nodejs.org/)
+[![License](https://img.shields.io/badge/license-MIT-green)](./LICENSE)
 
 [简体中文](./README.zh_CN.md)
 
-OpenClaw's WeChat channel plugin, supporting login authorization via QR code scanning.
+OpenClaw's Weixin channel plugin. Connect an OpenClaw Gateway to Weixin with QR-code login and receive and send messages through the Weixin backend.
 
-## Compatibility
+## Highlights
 
-| Plugin Version | OpenClaw Version       | npm dist-tag | Status      |
-|---------------|------------------------|--------------|-------------|
-| 2.0.x         | >=2026.3.22            | `latest`     | Active      |
-| 1.0.x         | >=2026.1.0 <2026.3.22  | `legacy`     | Maintenance |
+- QR-code login with automatic credential storage.
+- Multiple Weixin accounts on one OpenClaw Gateway.
+- Text, image, voice, file, and video messages.
+- Long-poll message delivery and typing indicators.
+- OpenClaw channel routing, pairing, and session isolation.
 
-> The plugin checks the host version at startup and will refuse to load if the
-> running OpenClaw version is outside the supported range.
+## Requirements
 
-## Prerequisites
+| Component | Requirement |
+| --- | --- |
+| Node.js | `>=22` |
+| OpenClaw runtime check | `>=2026.3.22` |
+| npm peer dependency | `>=2026.5.12` |
 
-[OpenClaw](https://docs.openclaw.ai/install) must be installed (the `openclaw` CLI needs to be available).
+Use OpenClaw `>=2026.5.12` when possible. The runtime guard currently accepts `>=2026.3.22`; npm installations using strict peer-dependency validation require the peer-dependency version.
 
-Check your version: `openclaw --version`
+OpenClaw must be installed and the `openclaw` CLI must be available. See the [OpenClaw installation guide](https://docs.openclaw.ai/install).
 
-## Quick Install
+```bash
+openclaw --version
+```
+
+## Quick start
+
+### 1. Install the plugin
 
 ```bash
 npx -y @tencent-weixin/openclaw-weixin-cli install
 ```
 
-## Manual Installation
-
-If the quick install doesn't work, follow these steps manually:
-
-### 1. Install the plugin
+If the installer is not suitable for your environment, install the plugin directly:
 
 ```bash
 openclaw plugins install "@tencent-weixin/openclaw-weixin"
@@ -44,44 +53,40 @@ openclaw plugins install "@tencent-weixin/openclaw-weixin"
 openclaw config set plugins.entries.openclaw-weixin.enabled true
 ```
 
-### 3. QR code login
+### 3. Log in with Weixin
 
 ```bash
 openclaw channels login --channel openclaw-weixin
 ```
 
-A QR code will appear in the terminal. Scan it with your phone and confirm the authorization. Once confirmed, the login credentials will be saved locally automatically — no further action is needed.
+Scan the QR code with Weixin and confirm the authorization. Credentials are stored locally after a successful login.
 
-### 4. Restart the gateway
+### 4. Restart and verify the Gateway
 
 ```bash
 openclaw gateway restart
+openclaw channels status
 ```
 
-## Adding More WeChat Accounts
+## Configuration
+
+### Multiple accounts
+
+Run the login command again for each account:
 
 ```bash
 openclaw channels login --channel openclaw-weixin
 ```
 
-Each QR code login creates a new account entry, supporting multiple WeChat accounts online simultaneously.
-
-## Multi-Account Context Isolation
-
-By default, DMs can share one session bucket. For **multiple logged-in WeChat accounts**, isolate by account + channel + sender:
+When multiple accounts are logged in, isolate direct-message sessions by account, channel, and peer:
 
 ```bash
 openclaw config set session.dmScope per-account-channel-peer
 ```
 
-## Custom BotAgent (optional)
+### Custom BotAgent
 
-Every outbound request to the WeChat backend carries a self-declared `bot_agent`
-identifier — analogous to an HTTP `User-Agent` — used for log attribution and
-monitoring aggregation. The default is `OpenClaw`. Declaring your own app name
-makes it much easier to trace your traffic in backend logs.
-
-Add one line to `openclaw.json`:
+Set an optional identifier for backend log attribution and monitoring:
 
 ```json
 {
@@ -93,254 +98,7 @@ Add one line to `openclaw.json`:
 }
 ```
 
-**Format** (UA-style):
-
-- One or more `Name/Version` tokens, space-separated
-- Each token may optionally be followed by ` (comment)`
-- ASCII only; total length ≤ 256 bytes
-- Invalid tokens are silently dropped during sanitization; falls back to
-  `OpenClaw` if nothing valid remains
-
-Examples that pass through unchanged:
-
-- `MyBot/1.2.0`
-- `MyBot/1.2.0 (region=cn;env=prod)`
-- `MyBot/1.2.0 LangChain/0.3.5`
-- `MyBot/1.2.0-rc.1+build.5`
-
-**Note**: `bot_agent` is for observability only — it is not used for
-authentication or routing. All registered agents on this plugin instance
-currently share the same `botAgent` declaration; per-agent overrides may be
-added in a future version if needed.
-
-## Backend API Protocol
-
-This plugin communicates with the backend gateway via HTTP JSON API. Developers integrating with their own backend need to implement the following interfaces.
-
-All endpoints use `POST` with JSON request and response bodies. Common request headers:
-
-| Header | Description |
-|--------|-------------|
-| `Content-Type` | `application/json` |
-| `AuthorizationType` | Fixed value `ilink_bot_token` |
-| `Authorization` | `Bearer <token>` (obtained after login) |
-| `X-WECHAT-UIN` | Base64-encoded random uint32 |
-
-### Endpoint List
-
-| Endpoint | Path | Description |
-|----------|------|-------------|
-| getUpdates | `getupdates` | Long-poll for new messages |
-| sendMessage | `sendmessage` | Send a message (text/image/video/file) |
-| getUploadUrl | `getuploadurl` | Get CDN upload pre-signed URL |
-| getConfig | `getconfig` | Get account config (typing ticket, etc.) |
-| sendTyping | `sendtyping` | Send/cancel typing status indicator |
-
-### getUpdates
-
-Long-polling endpoint. The server responds when new messages arrive or on timeout.
-
-**Request body:**
-
-```json
-{
-  "get_updates_buf": ""
-}
-```
-
-| Field | Type | Description |
-|-------|------|-------------|
-| `get_updates_buf` | `string` | Sync cursor from the previous response; empty string for the first request |
-
-**Response body:**
-
-```json
-{
-  "ret": 0,
-  "msgs": [...],
-  "get_updates_buf": "<new cursor>",
-  "longpolling_timeout_ms": 35000
-}
-```
-
-| Field | Type | Description |
-|-------|------|-------------|
-| `ret` | `number` | Return code, `0` = success |
-| `errcode` | `number?` | Error code (e.g., `-14` = session timeout) |
-| `errmsg` | `string?` | Error description |
-| `msgs` | `WeixinMessage[]` | Message list (structure below) |
-| `get_updates_buf` | `string` | New sync cursor to pass in the next request |
-| `longpolling_timeout_ms` | `number?` | Server-suggested long-poll timeout for the next request (ms) |
-
-### sendMessage
-
-Send a message to a user.
-
-**Request body:**
-
-```json
-{
-  "msg": {
-    "to_user_id": "<target user ID>",
-    "context_token": "<conversation context token>",
-    "item_list": [
-      {
-        "type": 1,
-        "text_item": { "text": "Hello" }
-      }
-    ]
-  }
-}
-```
-
-### getUploadUrl
-
-Get CDN upload pre-signed parameters. Call this endpoint before uploading a file to obtain `upload_param` and `thumb_upload_param`.
-
-**Request body:**
-
-```json
-{
-  "filekey": "<file identifier>",
-  "media_type": 1,
-  "to_user_id": "<target user ID>",
-  "rawsize": 12345,
-  "rawfilemd5": "<plaintext MD5>",
-  "filesize": 12352,
-  "thumb_rawsize": 1024,
-  "thumb_rawfilemd5": "<thumbnail plaintext MD5>",
-  "thumb_filesize": 1040
-}
-```
-
-| Field | Type | Description |
-|-------|------|-------------|
-| `media_type` | `number` | `1` = IMAGE, `2` = VIDEO, `3` = FILE |
-| `rawsize` | `number` | Original file plaintext size |
-| `rawfilemd5` | `string` | Original file plaintext MD5 |
-| `filesize` | `number` | Ciphertext size after AES-128-ECB encryption |
-| `thumb_rawsize` | `number?` | Thumbnail plaintext size (required for IMAGE/VIDEO) |
-| `thumb_rawfilemd5` | `string?` | Thumbnail plaintext MD5 (required for IMAGE/VIDEO) |
-| `thumb_filesize` | `number?` | Thumbnail ciphertext size (required for IMAGE/VIDEO) |
-
-**Response body:**
-
-```json
-{
-  "upload_param": "<original image upload encrypted parameters>",
-  "thumb_upload_param": "<thumbnail upload encrypted parameters>"
-}
-```
-
-### getConfig
-
-Get account configuration, including the typing ticket.
-
-**Request body:**
-
-```json
-{
-  "ilink_user_id": "<user ID>",
-  "context_token": "<optional, conversation context token>"
-}
-```
-
-**Response body:**
-
-```json
-{
-  "ret": 0,
-  "typing_ticket": "<base64-encoded typing ticket>"
-}
-```
-
-### sendTyping
-
-Send or cancel the typing status indicator.
-
-**Request body:**
-
-```json
-{
-  "ilink_user_id": "<user ID>",
-  "typing_ticket": "<obtained from getConfig>",
-  "status": 1
-}
-```
-
-| Field | Type | Description |
-|-------|------|-------------|
-| `status` | `number` | `1` = typing, `2` = cancel typing |
-
-### Message Structure
-
-#### WeixinMessage
-
-| Field | Type | Description |
-|-------|------|-------------|
-| `seq` | `number?` | Message sequence number |
-| `message_id` | `number?` | Unique message ID |
-| `from_user_id` | `string?` | Sender ID |
-| `to_user_id` | `string?` | Receiver ID |
-| `create_time_ms` | `number?` | Creation timestamp (ms) |
-| `session_id` | `string?` | Session ID |
-| `message_type` | `number?` | `1` = USER, `2` = BOT |
-| `message_state` | `number?` | `0` = NEW, `1` = GENERATING, `2` = FINISH |
-| `item_list` | `MessageItem[]?` | Message content list |
-| `context_token` | `string?` | Conversation context token, must be passed back when replying |
-
-#### MessageItem
-
-| Field | Type | Description |
-|-------|------|-------------|
-| `type` | `number` | `1` TEXT, `2` IMAGE, `3` VOICE, `4` FILE, `5` VIDEO |
-| `text_item` | `{ text: string }?` | Text content |
-| `image_item` | `ImageItem?` | Image (with CDN reference and AES key) |
-| `voice_item` | `VoiceItem?` | Voice (SILK encoded) |
-| `file_item` | `FileItem?` | File attachment |
-| `video_item` | `VideoItem?` | Video |
-| `ref_msg` | `RefMessage?` | Referenced message |
-
-#### CDN Media Reference (CDNMedia)
-
-All media types (image/voice/file/video) are transferred via CDN using AES-128-ECB encryption:
-
-| Field | Type | Description |
-|-------|------|-------------|
-| `encrypt_query_param` | `string?` | Encrypted parameters for CDN download/upload |
-| `aes_key` | `string?` | Base64-encoded AES-128 key |
-
-### CDN Upload Flow
-
-1. Calculate the file's plaintext size, MD5, and ciphertext size after AES-128-ECB encryption
-2. If a thumbnail is needed (image/video), calculate the thumbnail's plaintext and ciphertext parameters as well
-3. Call `getUploadUrl` to get `upload_param` (and `thumb_upload_param`)
-4. Encrypt the file content with AES-128-ECB and PUT upload to the CDN URL
-5. Encrypt and upload the thumbnail in the same way
-6. Use the returned `encrypt_query_param` to construct a `CDNMedia` reference, include it in the `MessageItem`, and send
-
-> For complete type definitions, see [`src/api/types.ts`](src/api/types.ts). For API call implementations, see [`src/api/api.ts`](src/api/api.ts).
-
-## Development
-
-This project requires Node.js >= 22.
-
-Install the locked dependencies and run the local CI checks:
-
-```bash
-npm ci --ignore-scripts
-npm run ci
-```
-
-Run the coverage check separately:
-
-```bash
-npm run test:coverage
-```
-
-Pull requests automatically run the same quality, unit test, coverage, build, and package smoke checks in GitHub Actions.
-
-For CI design and maintenance details, see the [CI Guide](./docs/ci.md).
+`botAgent` is used for observability only. It is not an authentication credential and does not control message routing.
 
 ## Uninstall
 
@@ -350,25 +108,59 @@ openclaw plugins uninstall @tencent-weixin/openclaw-weixin
 
 ## Troubleshooting
 
-### "requires OpenClaw >=2026.3.22" error
+### The plugin reports an unsupported OpenClaw version
 
-Your OpenClaw version is too old for this plugin version. Check with:
+Check the host version:
 
 ```bash
 openclaw --version
 ```
 
-Install the legacy plugin line instead:
+Upgrade OpenClaw to a supported version, then restart the Gateway.
 
-```bash
-openclaw plugins install @tencent-weixin/openclaw-weixin@legacy
-```
+### The channel shows `OK` but does not connect
 
-### Channel shows "OK" but doesn't connect
-
-Ensure `plugins.entries.openclaw-weixin.enabled` is `true` in `~/.openclaw/openclaw.json`:
+Make sure the plugin is enabled and restart the Gateway:
 
 ```bash
 openclaw config set plugins.entries.openclaw-weixin.enabled true
 openclaw gateway restart
 ```
+
+If the problem persists, inspect the Gateway log and verify that the account has completed QR-code login.
+
+## Documentation
+
+| Need | Start here |
+| --- | --- |
+| Backend integration | [Weixin backend API protocol](./docs/protocol.md) |
+| CI and local quality checks | [CI guide](./docs/ci.md) |
+| OpenClaw channel configuration | [OpenClaw channels](https://docs.openclaw.ai/channels) |
+| Release history | [CHANGELOG.md](./CHANGELOG.md) |
+
+The backend protocol document is intended for developers implementing or integrating a compatible backend. It is not required for normal plugin installation.
+
+## Development
+
+This repository uses npm and requires Node.js `>=22`.
+
+```bash
+npm ci --ignore-scripts
+npm run ci
+```
+
+Run coverage separately when changing behavior or tests:
+
+```bash
+npm run test:coverage
+```
+
+Pull requests run the same quality, unit-test, coverage, build, and package smoke checks in GitHub Actions. See the [CI guide](./docs/ci.md) for details.
+
+## Contributing
+
+Bug reports, documentation improvements, tests, and code contributions are welcome. Please keep pull requests focused and include validation details. For changes to the backend integration, update the [protocol documentation](./docs/protocol.md) together with the implementation.
+
+## License
+
+[MIT](./LICENSE)

--- a/README.zh_CN.md
+++ b/README.zh_CN.md
@@ -1,37 +1,47 @@
-# 微信
+# OpenClaw 微信渠道
 
 [![CI](https://github.com/Tencent/openclaw-weixin/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/Tencent/openclaw-weixin/actions/workflows/ci.yml)
+[![npm](https://img.shields.io/npm/v/@tencent-weixin/openclaw-weixin)](https://www.npmjs.com/package/@tencent-weixin/openclaw-weixin)
+[![Node.js](https://img.shields.io/node/v/@tencent-weixin/openclaw-weixin)](https://nodejs.org/)
+[![License](https://img.shields.io/badge/license-MIT-green)](./LICENSE)
 
 [English](./README.md)
 
-OpenClaw 的微信渠道插件，支持通过扫码完成登录授权。
+OpenClaw 的微信渠道插件。通过扫码登录将 OpenClaw Gateway 连接到微信，并通过微信后端收发消息。
 
-## 兼容性
+## 主要能力
 
-| 插件版本 | OpenClaw 版本            | npm dist-tag | 状态   |
-|---------|--------------------------|--------------|--------|
-| 2.0.x   | >=2026.3.22              | `latest`     | 活跃   |
-| 1.0.x   | >=2026.1.0 <2026.3.22    | `legacy`     | 维护中 |
+- 扫码登录并自动保存登录凭证。
+- 一个 OpenClaw Gateway 同时运行多个微信账号。
+- 支持文本、图片、语音、文件和视频消息。
+- 长轮询收取消息，并支持输入状态提示。
+- 集成 OpenClaw 渠道路由、配对和会话隔离能力。
 
-> 插件在启动时会检查宿主版本，如果运行的 OpenClaw 版本超出支持范围，插件将拒绝加载。
+## 环境要求
 
-## 前提条件
+| 组件 | 要求 |
+| --- | --- |
+| Node.js | `>=22` |
+| OpenClaw 运行时检查 | `>=2026.3.22` |
+| npm peer dependency | `>=2026.5.12` |
 
-已安装 [OpenClaw](https://docs.openclaw.ai/install)（需要 `openclaw` CLI 可用）。
+建议尽量使用 `OpenClaw >=2026.5.12`。当前运行时兼容检查接受 `>=2026.3.22`；如果 npm 使用严格的 peer dependency 校验，则需要满足 peer dependency 要求的版本。
 
-查看版本：`openclaw --version`
+必须先安装 OpenClaw，并确保 `openclaw` 命令可用。请参阅 [OpenClaw 安装指南](https://docs.openclaw.ai/install)。
 
-## 一键安装
+```bash
+openclaw --version
+```
+
+## 快速开始
+
+### 1. 安装插件
 
 ```bash
 npx -y @tencent-weixin/openclaw-weixin-cli install
 ```
 
-## 手动安装
-
-如果一键安装不适用，可以按以下步骤手动操作：
-
-### 1. 安装插件
+如果当前环境不适合使用安装器，也可以直接安装插件：
 
 ```bash
 openclaw plugins install "@tencent-weixin/openclaw-weixin"
@@ -43,43 +53,40 @@ openclaw plugins install "@tencent-weixin/openclaw-weixin"
 openclaw config set plugins.entries.openclaw-weixin.enabled true
 ```
 
-### 3. 扫码登录
+### 3. 使用微信扫码登录
 
 ```bash
 openclaw channels login --channel openclaw-weixin
 ```
 
-终端会显示一个二维码，用手机扫码并在手机上确认授权。确认后，登录凭证会自动保存到本地，无需额外操作。
+使用微信扫描二维码并确认授权。登录成功后，凭证会自动保存到本地。
 
-### 4. 重启 gateway
+### 4. 重启并检查 Gateway
 
 ```bash
 openclaw gateway restart
+openclaw channels status
 ```
 
-## 添加更多微信账号
+## 配置
+
+### 多账号
+
+每个账号再次执行登录命令：
 
 ```bash
 openclaw channels login --channel openclaw-weixin
 ```
 
-每次扫码登录都会创建一个新的账号条目，支持多个微信号同时在线。
-
-## 多账号上下文隔离
-
-默认情况下，私聊可能共用同一会话桶。**多个微信号同时登录**时，建议按「账号 + 渠道 + 对端」隔离：
+同时登录多个账号时，建议按账号、渠道和对端隔离私聊会话：
 
 ```bash
 openclaw config set session.dmScope per-account-channel-peer
 ```
 
-## 自定义 BotAgent（可选）
+### 自定义 BotAgent
 
-每条出站请求会带一个自我声明的 `bot_agent` 字段——类似 HTTP `User-Agent`——用于
-后台日志归因和监控聚合。**默认值为 `OpenClaw`**。声明自己的应用名能让你的流量
-在后台日志中更容易识别。
-
-在 `openclaw.json` 中加一行即可：
+可以设置一个用于后台日志归因和监控的标识：
 
 ```json
 {
@@ -91,252 +98,7 @@ openclaw config set session.dmScope per-account-channel-peer
 }
 ```
 
-**格式规范**（UA 风格）：
-
-- 一个或多个 `Name/Version` token，空格分隔
-- 每个 token 可选地跟一个 ` (comment)`
-- 仅允许 ASCII 字符；总长 ≤ 256 字节
-- 不合规的 token 在清洗时静默丢弃；如果最终为空，回退到 `OpenClaw`
-
-可直接使用的示例：
-
-- `MyBot/1.2.0`
-- `MyBot/1.2.0 (region=cn;env=prod)`
-- `MyBot/1.2.0 LangChain/0.3.5`
-- `MyBot/1.2.0-rc.1+build.5`
-
-**注意**：`bot_agent` 仅用于观测，**不参与鉴权或路由**。当前本插件实例下所有
-已注册的 agent 共享同一个 `botAgent` 声明；如有需要按 agent 单独标识的场景，
-可在后续版本扩展配置。
-
-## 后端 API 协议
-
-本插件通过 HTTP JSON API 与后端网关通信。二次开发者若需对接自有后端，需实现以下接口。
-
-所有接口均为 `POST`，请求和响应均为 JSON。通用请求头：
-
-| Header | 说明 |
-|--------|------|
-| `Content-Type` | `application/json` |
-| `AuthorizationType` | 固定值 `ilink_bot_token` |
-| `Authorization` | `Bearer <token>`（登录后获取） |
-| `X-WECHAT-UIN` | 随机 uint32 的 base64 编码 |
-
-### 接口列表
-
-| 接口 | 路径 | 说明 |
-|------|------|------|
-| getUpdates | `getupdates` | 长轮询获取新消息 |
-| sendMessage | `sendmessage` | 发送消息（文本/图片/视频/文件） |
-| getUploadUrl | `getuploadurl` | 获取 CDN 上传预签名 URL |
-| getConfig | `getconfig` | 获取账号配置（typing ticket 等） |
-| sendTyping | `sendtyping` | 发送/取消输入状态指示 |
-
-### getUpdates
-
-长轮询接口。服务端在有新消息或超时后返回。
-
-**请求体：**
-
-```json
-{
-  "get_updates_buf": ""
-}
-```
-
-| 字段 | 类型 | 说明 |
-|------|------|------|
-| `get_updates_buf` | `string` | 上次响应返回的同步游标，首次请求传空字符串 |
-
-**响应体：**
-
-```json
-{
-  "ret": 0,
-  "msgs": [...],
-  "get_updates_buf": "<新游标>",
-  "longpolling_timeout_ms": 35000
-}
-```
-
-| 字段 | 类型 | 说明 |
-|------|------|------|
-| `ret` | `number` | 返回码，`0` = 成功 |
-| `errcode` | `number?` | 错误码（如 `-14` = 会话超时） |
-| `errmsg` | `string?` | 错误描述 |
-| `msgs` | `WeixinMessage[]` | 消息列表（结构见下方） |
-| `get_updates_buf` | `string` | 新的同步游标，下次请求时回传 |
-| `longpolling_timeout_ms` | `number?` | 服务端建议的下次长轮询超时（ms） |
-
-### sendMessage
-
-发送一条消息给用户。
-
-**请求体：**
-
-```json
-{
-  "msg": {
-    "to_user_id": "<目标用户 ID>",
-    "context_token": "<会话上下文令牌>",
-    "item_list": [
-      {
-        "type": 1,
-        "text_item": { "text": "你好" }
-      }
-    ]
-  }
-}
-```
-
-### getUploadUrl
-
-获取 CDN 上传预签名参数。上传文件前需先调用此接口获取 `upload_param` 和 `thumb_upload_param`。
-
-**请求体：**
-
-```json
-{
-  "filekey": "<文件标识>",
-  "media_type": 1,
-  "to_user_id": "<目标用户 ID>",
-  "rawsize": 12345,
-  "rawfilemd5": "<明文 MD5>",
-  "filesize": 12352,
-  "thumb_rawsize": 1024,
-  "thumb_rawfilemd5": "<缩略图明文 MD5>",
-  "thumb_filesize": 1040
-}
-```
-
-| 字段 | 类型 | 说明 |
-|------|------|------|
-| `media_type` | `number` | `1` = IMAGE, `2` = VIDEO, `3` = FILE |
-| `rawsize` | `number` | 原文件明文大小 |
-| `rawfilemd5` | `string` | 原文件明文 MD5 |
-| `filesize` | `number` | AES-128-ECB 加密后的密文大小 |
-| `thumb_rawsize` | `number?` | 缩略图明文大小（IMAGE/VIDEO 时必填） |
-| `thumb_rawfilemd5` | `string?` | 缩略图明文 MD5（IMAGE/VIDEO 时必填） |
-| `thumb_filesize` | `number?` | 缩略图密文大小（IMAGE/VIDEO 时必填） |
-
-**响应体：**
-
-```json
-{
-  "upload_param": "<原图上传加密参数>",
-  "thumb_upload_param": "<缩略图上传加密参数>"
-}
-```
-
-### getConfig
-
-获取账号配置，包括 typing ticket。
-
-**请求体：**
-
-```json
-{
-  "ilink_user_id": "<用户 ID>",
-  "context_token": "<可选，会话上下文令牌>"
-}
-```
-
-**响应体：**
-
-```json
-{
-  "ret": 0,
-  "typing_ticket": "<base64 编码的 typing ticket>"
-}
-```
-
-### sendTyping
-
-发送或取消输入状态指示。
-
-**请求体：**
-
-```json
-{
-  "ilink_user_id": "<用户 ID>",
-  "typing_ticket": "<从 getConfig 获取>",
-  "status": 1
-}
-```
-
-| 字段 | 类型 | 说明 |
-|------|------|------|
-| `status` | `number` | `1` = 正在输入，`2` = 取消输入 |
-
-### 消息结构
-
-#### WeixinMessage
-
-| 字段 | 类型 | 说明 |
-|------|------|------|
-| `seq` | `number?` | 消息序列号 |
-| `message_id` | `number?` | 消息唯一 ID |
-| `from_user_id` | `string?` | 发送者 ID |
-| `to_user_id` | `string?` | 接收者 ID |
-| `create_time_ms` | `number?` | 创建时间戳（ms） |
-| `session_id` | `string?` | 会话 ID |
-| `message_type` | `number?` | `1` = USER, `2` = BOT |
-| `message_state` | `number?` | `0` = NEW, `1` = GENERATING, `2` = FINISH |
-| `item_list` | `MessageItem[]?` | 消息内容列表 |
-| `context_token` | `string?` | 会话上下文令牌，回复时需回传 |
-
-#### MessageItem
-
-| 字段 | 类型 | 说明 |
-|------|------|------|
-| `type` | `number` | `1` TEXT, `2` IMAGE, `3` VOICE, `4` FILE, `5` VIDEO |
-| `text_item` | `{ text: string }?` | 文本内容 |
-| `image_item` | `ImageItem?` | 图片（含 CDN 引用和 AES 密钥） |
-| `voice_item` | `VoiceItem?` | 语音（SILK 编码） |
-| `file_item` | `FileItem?` | 文件附件 |
-| `video_item` | `VideoItem?` | 视频 |
-| `ref_msg` | `RefMessage?` | 引用消息 |
-
-#### CDN 媒体引用 (CDNMedia)
-
-所有媒体类型（图片/语音/文件/视频）通过 CDN 传输，使用 AES-128-ECB 加密：
-
-| 字段 | 类型 | 说明 |
-|------|------|------|
-| `encrypt_query_param` | `string?` | CDN 下载/上传的加密参数 |
-| `aes_key` | `string?` | base64 编码的 AES-128 密钥 |
-
-### CDN 上传流程
-
-1. 计算文件明文大小、MD5，以及 AES-128-ECB 加密后的密文大小
-2. 如需缩略图（图片/视频），同样计算缩略图的明文和密文参数
-3. 调用 `getUploadUrl` 获取 `upload_param`（和 `thumb_upload_param`）
-4. 使用 AES-128-ECB 加密文件内容，PUT 上传到 CDN URL
-5. 缩略图同理加密并上传
-6. 使用返回的 `encrypt_query_param` 构造 `CDNMedia` 引用，放入 `MessageItem` 发送
-
-> 完整的类型定义见 [`src/api/types.ts`](src/api/types.ts)，API 调用实现见 [`src/api/api.ts`](src/api/api.ts)。
-
-## 开发与 CI
-
-本项目要求 Node.js >= 22。
-
-安装锁定版本的依赖并执行本地 CI 检查：
-
-```bash
-npm ci --ignore-scripts
-npm run ci
-```
-
-覆盖率检查单独执行：
-
-```bash
-npm run test:coverage
-```
-
-提交 Pull Request 后，GitHub Actions 会自动执行质量检查、单元测试、覆盖率、构建和 npm 包冒烟检查。
-
-CI 的设计和维护说明见 [CI 指南](./docs/ci_zh_CN.md)。
+`botAgent` 仅用于观测，不是鉴权凭证，也不控制消息路由。
 
 ## 卸载
 
@@ -346,25 +108,59 @@ openclaw plugins uninstall @tencent-weixin/openclaw-weixin
 
 ## 故障排查
 
-### "requires OpenClaw >=2026.3.22" 报错
+### 插件报告 OpenClaw 版本不受支持
 
-你的 OpenClaw 版本太旧，不兼容当前插件版本。检查版本：
+检查宿主版本：
 
 ```bash
 openclaw --version
 ```
 
-安装旧版插件线：
+将 OpenClaw 升级到受支持的版本，然后重启 Gateway。
 
-```bash
-openclaw plugins install @tencent-weixin/openclaw-weixin@legacy
-```
+### Channel 显示 `OK` 但没有连接
 
-### Channel 显示 "OK" 但未连接
-
-确保 `~/.openclaw/openclaw.json` 中 `plugins.entries.openclaw-weixin.enabled` 为 `true`：
+确认插件已启用，然后重启 Gateway：
 
 ```bash
 openclaw config set plugins.entries.openclaw-weixin.enabled true
 openclaw gateway restart
 ```
+
+如果问题仍然存在，请检查 Gateway 日志，并确认账号已经完成扫码登录。
+
+## 文档
+
+| 需求 | 文档 |
+| --- | --- |
+| 后端对接 | [微信后端 API 协议](./docs/protocol_zh_CN.md) |
+| CI 和本地质量检查 | [CI 指南](./docs/ci_zh_CN.md) |
+| OpenClaw 渠道配置 | [OpenClaw Channels](https://docs.openclaw.ai/channels) |
+| 发布历史 | [CHANGELOG.zh_CN.md](./CHANGELOG.zh_CN.md) |
+
+后端协议文档面向实现或对接兼容后端的开发者，普通用户安装插件时不需要阅读。
+
+## 开发
+
+本项目使用 npm，并要求 Node.js `>=22`。
+
+```bash
+npm ci --ignore-scripts
+npm run ci
+```
+
+修改功能或测试时，可以单独运行覆盖率检查：
+
+```bash
+npm run test:coverage
+```
+
+Pull Request 会在 GitHub Actions 中执行质量检查、单元测试、覆盖率、构建和 npm 包冒烟测试。详细说明见 [CI 指南](./docs/ci_zh_CN.md)。
+
+## 参与贡献
+
+欢迎提交问题、改进文档、补充测试和贡献代码。请保持 Pull Request 聚焦，并附上验证结果。修改后端集成时，请同步更新[协议文档](./docs/protocol_zh_CN.md)。
+
+## License
+
+[MIT](./LICENSE)

--- a/docs/protocol.md
+++ b/docs/protocol.md
@@ -2,7 +2,21 @@
 
 This document describes the HTTP JSON protocol used by the `openclaw-weixin` channel plugin. It is intended for developers implementing or integrating a compatible Weixin backend. Normal plugin users only need the [main README](../README.md).
 
-The TypeScript implementation is the source of truth. See [`src/api/api.ts`](../src/api/api.ts), [`src/api/types.ts`](../src/api/types.ts), and [`src/auth/login-qr.ts`](../src/auth/login-qr.ts) when this document needs to be updated.
+[简体中文](./protocol_zh_CN.md)
+
+## How to read this reference
+
+This reference is based on the current repository's client code. It distinguishes three kinds of information:
+
+- **Fields and examples** describe the wire format represented by the client types and request builders.
+- **Client behavior** describes what this plugin currently sends, accepts, or retries.
+- **Integration guidance** gives recommendations for other implementations.
+
+Client types and behavior do not establish the complete server contract. In particular, a TypeScript optional field does not prove that the server accepts requests without it, and a field defined in a type does not imply that the plugin implements every associated feature.
+
+Unless otherwise stated, JSON examples illustrate selected fields and are not verified minimal requests or exhaustive responses. Replace placeholders with actual values. `channel_version` is populated from package metadata; `2.4.8` is an example value.
+
+Source references: [`src/api/api.ts`](../src/api/api.ts), [`src/api/types.ts`](../src/api/types.ts), and [`src/auth/login-qr.ts`](../src/auth/login-qr.ts). Server requirements beyond what these sources show need separate verification.
 
 ## Scope and transport
 
@@ -31,7 +45,7 @@ The following headers are added by the plugin where applicable:
 | `iLink-App-ClientVersion` | Plugin version encoded as `0x00MMNNPP` and sent as a decimal string |
 | `SKRouteTag` | Optional route tag configured by the deployment |
 
-QR-code status polling uses the common application headers but does not use a bot token. The QR-code request is also unauthenticated.
+Client behavior: QR-code status polling sends the application headers (`iLink-App-Id`, `iLink-App-ClientVersion`, and optional `SKRouteTag`). It does not add `AuthorizationType`, `Authorization`, or `X-WECHAT-UIN`. The QR-code POST request uses the JSON POST headers, including `AuthorizationType` and `X-WECHAT-UIN`, but omits `Authorization` and `base_info`.
 
 ### `base_info`
 
@@ -48,13 +62,26 @@ Authenticated bot POST requests include a `base_info` object:
 
 `channel_version` is the plugin version. `bot_agent` is an optional, sanitized observability identifier configured through `channels.openclaw-weixin.botAgent`; it is not used for authentication or routing.
 
+Client behavior: `buildBaseInfo()` always supplies both fields. `bot_agent` defaults to `OpenClaw`. Custom values use ASCII `Name/Version` tokens with optional comments, with a maximum of 256 bytes after sanitization. Invalid tokens are dropped; an empty result falls back to `OpenClaw`. This declaration is shared across accounts in the plugin instance.
+
 ### Return values and errors
 
-Successful JSON responses generally use `ret: 0`. When a response contains a non-zero `ret` or an `errcode`, the client should inspect `errmsg` and decide whether to retry or report the error.
+The response types use fields such as `ret`, `errcode`, and `errmsg`; they are not present on every endpoint. `ret: 0` represents success where used.
 
-- HTTP errors are transport failures and should be handled separately from application-level `ret` values.
-- `getUpdates` uses client-side timeout as normal long-poll control flow and returns an empty message list for a retry.
-- Error responses must not include or log bot tokens, QR-code values, or other credentials.
+Current client behavior differs by operation:
+
+| Operation | Application response handling |
+| --- | --- |
+| `getUpdates` | The monitor checks non-zero `ret` or `errcode`. Either field equal to `-14` triggers a one-hour account session pause; other failures follow the monitor's retry/backoff policy. |
+| `sendMessage` | A non-zero `ret` throws; an absent `ret` does not trigger this check. |
+| `getUploadUrl` | The upload caller requires a nonempty `upload_full_url` or `upload_param`; it does not explicitly check `ret`. |
+| `getConfig` | The cache layer accepts configuration only when `ret === 0`; failures use cached/default configuration and schedule another attempt. |
+| `sendTyping` | The wrapper does not parse the response body or check its business return code. |
+| `notifyStart` / `notifyStop` | Non-zero `ret` or request failures are logged as warnings by channel lifecycle handlers, without blocking startup/shutdown. |
+
+The JSON fetch wrappers throw on non-successful HTTP status. `getUpdates` converts a timeout or external cancellation into an empty result; cancellation lets the monitor exit rather than continue polling. QR status polling converts request failures into `wait`.
+
+Integration guidance: handle HTTP status separately from business return codes, define retry behavior per operation, and redact credentials in diagnostic output. These are recommendations, not a claim that the current client applies a single uniform error or redaction policy.
 
 ## QR-code login
 
@@ -68,7 +95,7 @@ Request body:
 
 ```json
 {
-  "local_token_list": ["<previously issued token>" ]
+  "local_token_list": []
 }
 ```
 
@@ -176,7 +203,7 @@ Response:
 | `get_updates_buf` | `string` | Cursor to send in the next request |
 | `longpolling_timeout_ms` | `number` | Optional server-suggested timeout in milliseconds |
 
-`sync_buf` is retained only for compatibility with older implementations. New integrations should use `get_updates_buf`.
+`sync_buf` remains deprecated in the TypeScript types. The current request builder sends only `get_updates_buf`, and the monitor does not use `sync_buf` as a response fallback. It saves a returned cursor only when `get_updates_buf` is nonempty.
 
 ### `sendMessage`
 
@@ -184,12 +211,16 @@ Response:
 POST /ilink/bot/sendmessage
 ```
 
-Request:
+Example matching the current text-message builder when a context token is available (`run_id` is additionally included when supplied):
 
 ```json
 {
   "msg": {
+    "from_user_id": "",
     "to_user_id": "<target user id>",
+    "client_id": "<client-generated id>",
+    "message_type": 2,
+    "message_state": 2,
     "context_token": "<conversation context token>",
     "item_list": [
       {
@@ -214,7 +245,7 @@ Response:
 }
 ```
 
-The `context_token` received with an inbound message must be passed back when the reply belongs to that conversation.
+Integration guidance: pass back the inbound `context_token` when replying to that conversation. Client behavior: the send helper logs a warning and still sends if the token is missing; this does not establish whether the server will accept that request. Media captions and media items are currently sent in separate requests, each with its own `client_id`.
 
 ### `getUploadUrl`
 
@@ -264,6 +295,8 @@ Response:
 ```
 
 The client prefers `upload_full_url`. If it is absent, it constructs a CDN upload URL from `upload_param` and `filekey`.
+
+The types expose thumbnail request fields and `thumb_upload_param`. Current client behavior: the shared upload pipeline always sends `no_need_thumb: true`, uploads only the original file, and does not consume `thumb_upload_param`. These fields do not indicate implemented thumbnail upload support. Likewise, `media_type: 4` is defined in the types, while the current file-send pipeline selects image, video, or file upload.
 
 ### `getConfig`
 
@@ -346,6 +379,8 @@ The plugin sends `notifyStart` when a channel client starts and `notifyStop` whe
 
 ## Message model
 
+These tables summarize client-side types. `WeixinMessage`, `MessageItem`, and media-object properties are optional in the TypeScript definitions; the tables do not declare server-required fields. Fields such as `group_id` describe the type surface, not a guarantee of plugin feature support.
+
 ### `WeixinMessage`
 
 | Field | Type | Description |
@@ -382,6 +417,21 @@ Common item fields include `create_time_ms`, `update_time_ms`, `is_completed`, `
 
 `voice_item` may include a transcript in `text`. Media items can include a `media` object, and images and videos can additionally include `thumb_media`.
 
+### Media fields used by the client
+
+| Field | Type | Current use |
+| --- | --- | --- |
+| `image_item.aeskey` | `string` | Inbound AES key as 32 hex characters; takes precedence over `media.aes_key`. |
+| `image_item.mid_size` | `number` | Ciphertext byte count set by the image sender. |
+| `video_item.video_size` | `number` | Ciphertext byte count set by the video sender. |
+| `file_item.file_name` | `string` | Attachment filename. |
+| `file_item.len` | `string` | Plaintext byte count encoded as a decimal string by the file sender. |
+| `voice_item.text` | `string` | Transcript when present. |
+| `voice_item.encode_type` | `number` | Codec identifier in the types; does not imply decoding support for every codec. |
+| `voice_item.sample_rate` / `playtime` | `number` | Sample rate in Hz / duration in milliseconds. |
+
+See [protocol types](../src/api/types.ts) for the remaining fields and [message builders](../src/messaging/send.ts) for outgoing payloads.
+
 ### CDN media reference
 
 ```json
@@ -399,7 +449,7 @@ The client prefers `full_url`. When a full URL is unavailable, a compatible depl
 <cdn_base_url>/download?encrypted_query_param=<url-encoded encrypt_query_param>
 ```
 
-The AES key may be encoded as base64 of 16 raw bytes or as base64 of a 32-character hexadecimal key, depending on the media type.
+The download decoder accepts base64 of either 16 raw bytes or a 32-character hexadecimal key. Current image, video, and file senders all encode the hexadecimal key string as base64. These describe accepted encodings and outgoing behavior, respectively; they are not a mandatory encoding split by media type.
 
 ## CDN media flow
 
@@ -414,14 +464,16 @@ The AES key may be encoded as base64 of 16 raw bytes or as base64 of a 32-charac
 7. Read the `x-encrypted-param` response header.
 8. Put the returned download parameter and AES key into the media reference sent through `sendMessage`.
 
-The current client uploads encrypted bytes with HTTP `POST`, not `PUT`. Image and video thumbnails follow the same flow when the backend requests them.
+Current client behavior: uploads use HTTP `POST`. Only original files are uploaded, with `no_need_thumb: true`; there is no thumbnail upload step.
+
+Success requires HTTP `200` and a nonempty `x-encrypted-param` response header. HTTP 4xx errors abort immediately. Other failures, including a missing response header, are attempted up to three times total. This is the plugin's current acceptance and retry policy.
 
 ### Download
 
-1. Read `full_url` or construct a compatible CDN download URL from `encrypt_query_param`.
+1. Prefer `full_url`. The current client enables URL fallback and constructs a CDN download URL from `encrypt_query_param` when a full URL is absent.
 2. Download the bytes with HTTP `GET`.
-3. Decode the AES key from `aes_key` or the media-specific AES key field.
-4. Decrypt with AES-128-ECB and remove PKCS#7 padding.
+3. For images, prefer the hex key in `image_item.aeskey`, then `image_item.media.aes_key`. If neither is available, use the downloaded image bytes as plaintext.
+4. For encrypted images, voice, files, and videos, decode the key and decrypt with AES-128-ECB and PKCS#7 padding. Voice, file, and video items without `media.aes_key` are skipped by the current media downloader.
 
 ## Source references
 
@@ -430,3 +482,9 @@ The current client uploads encrypted bytes with HTTP `POST`, not `PUT`. Image an
 - [QR-code login flow](../src/auth/login-qr.ts)
 - [CDN upload implementation](../src/cdn/upload.ts)
 - [CDN encryption utilities](../src/cdn/aes-ecb.ts)
+- [Message builders](../src/messaging/send.ts)
+- [Inbound media handling](../src/media/media-download.ts)
+- [CDN upload transport](../src/cdn/cdn-upload.ts)
+- [Message polling and retries](../src/monitor/monitor.ts)
+- [Configuration cache](../src/api/config-cache.ts)
+- [Channel lifecycle](../src/channel.ts)

--- a/docs/protocol.md
+++ b/docs/protocol.md
@@ -1,0 +1,432 @@
+# Weixin Backend API Protocol
+
+This document describes the HTTP JSON protocol used by the `openclaw-weixin` channel plugin. It is intended for developers implementing or integrating a compatible Weixin backend. Normal plugin users only need the [main README](../README.md).
+
+The TypeScript implementation is the source of truth. See [`src/api/api.ts`](../src/api/api.ts), [`src/api/types.ts`](../src/api/types.ts), and [`src/auth/login-qr.ts`](../src/auth/login-qr.ts) when this document needs to be updated.
+
+## Scope and transport
+
+- API requests use JSON over HTTPS.
+- API paths are relative to the current API base URL.
+- Normal API methods use `POST`; QR-code status polling uses `GET`.
+- JSON byte fields are represented as base64 strings.
+- The default API base URL is `https://ilinkai.weixin.qq.com`.
+- The default CDN base URL is `https://novac2c.cdn.weixin.qq.com/c2c`.
+
+The QR-code flow starts at the fixed API base URL. After a successful redirect response, the client may poll QR status at the returned host. For CDN media, a server-provided full URL takes precedence over a URL constructed from the configured CDN base URL.
+
+## Authentication and common metadata
+
+### Request headers
+
+The following headers are added by the plugin where applicable:
+
+| Header | Value |
+| --- | --- |
+| `Content-Type` | `application/json` for JSON POST requests |
+| `AuthorizationType` | `ilink_bot_token` |
+| `Authorization` | `Bearer <bot_token>` for authenticated bot API requests |
+| `X-WECHAT-UIN` | Base64-encoded decimal representation of a random uint32 |
+| `iLink-App-Id` | The plugin application ID, currently `bot` |
+| `iLink-App-ClientVersion` | Plugin version encoded as `0x00MMNNPP` and sent as a decimal string |
+| `SKRouteTag` | Optional route tag configured by the deployment |
+
+QR-code status polling uses the common application headers but does not use a bot token. The QR-code request is also unauthenticated.
+
+### `base_info`
+
+Authenticated bot POST requests include a `base_info` object:
+
+```json
+{
+  "base_info": {
+    "channel_version": "2.4.8",
+    "bot_agent": "OpenClaw"
+  }
+}
+```
+
+`channel_version` is the plugin version. `bot_agent` is an optional, sanitized observability identifier configured through `channels.openclaw-weixin.botAgent`; it is not used for authentication or routing.
+
+### Return values and errors
+
+Successful JSON responses generally use `ret: 0`. When a response contains a non-zero `ret` or an `errcode`, the client should inspect `errmsg` and decide whether to retry or report the error.
+
+- HTTP errors are transport failures and should be handled separately from application-level `ret` values.
+- `getUpdates` uses client-side timeout as normal long-poll control flow and returns an empty message list for a retry.
+- Error responses must not include or log bot tokens, QR-code values, or other credentials.
+
+## QR-code login
+
+### Get a QR code
+
+```http
+POST /ilink/bot/get_bot_qrcode?bot_type=3
+```
+
+Request body:
+
+```json
+{
+  "local_token_list": ["<previously issued token>" ]
+}
+```
+
+`local_token_list` may be empty. The client sends at most the most recent ten locally stored bot tokens.
+
+Response body:
+
+```json
+{
+  "qrcode": "<qrcode value>",
+  "qrcode_img_content": "<url or content to display as a QR code>"
+}
+```
+
+### Poll QR-code status
+
+```http
+GET /ilink/bot/get_qrcode_status?qrcode=<encoded_qrcode>
+```
+
+When the server requests verification, the client adds:
+
+```http
+GET /ilink/bot/get_qrcode_status?qrcode=<encoded_qrcode>&verify_code=<encoded_code>
+```
+
+Response body:
+
+```json
+{
+  "status": "confirmed",
+  "bot_token": "<bot token>",
+  "ilink_bot_id": "<bot account id>",
+  "baseurl": "https://<api-host>",
+  "ilink_user_id": "<scanning user id>"
+}
+```
+
+The client handles these statuses:
+
+| Status | Meaning |
+| --- | --- |
+| `wait` | Waiting for a scan or state change |
+| `scaned` | QR code was scanned; verification continues |
+| `confirmed` | Login succeeded and credentials can be stored |
+| `expired` | QR code expired and may be refreshed |
+| `need_verifycode` | The user must provide the displayed verification code |
+| `verify_code_blocked` | Too many verification failures; refresh or stop |
+| `scaned_but_redirect` | Continue polling at `redirect_host` when present |
+| `binded_redirect` | The bot is already bound to this OpenClaw instance |
+
+## Bot API
+
+### Endpoint overview
+
+| Operation | Method and path | Purpose |
+| --- | --- | --- |
+| `getUpdates` | `POST /ilink/bot/getupdates` | Long-poll for inbound messages |
+| `getUploadUrl` | `POST /ilink/bot/getuploadurl` | Get media upload parameters |
+| `sendMessage` | `POST /ilink/bot/sendmessage` | Send a message |
+| `getConfig` | `POST /ilink/bot/getconfig` | Get account configuration and typing ticket |
+| `sendTyping` | `POST /ilink/bot/sendtyping` | Set or cancel typing status |
+| `notifyStart` | `POST /ilink/bot/msg/notifystart` | Notify the backend that the client started |
+| `notifyStop` | `POST /ilink/bot/msg/notifystop` | Notify the backend that the client stopped |
+
+All requests in this section include the common headers, bot authorization, and `base_info` unless stated otherwise.
+
+### `getUpdates`
+
+```http
+POST /ilink/bot/getupdates
+```
+
+Request:
+
+```json
+{
+  "get_updates_buf": "",
+  "base_info": {
+    "channel_version": "2.4.8",
+    "bot_agent": "OpenClaw"
+  }
+}
+```
+
+The client sends the previous response's `get_updates_buf`. It sends an empty string for the first request or after a reset. The server should hold the request until a message is available or the long-poll timeout is reached.
+
+Response:
+
+```json
+{
+  "ret": 0,
+  "msgs": [],
+  "get_updates_buf": "<next cursor>",
+  "longpolling_timeout_ms": 35000
+}
+```
+
+| Field | Type | Description |
+| --- | --- | --- |
+| `ret` | `number` | `0` means success |
+| `errcode` | `number` | Optional application error code |
+| `errmsg` | `string` | Optional error description |
+| `msgs` | `WeixinMessage[]` | Inbound messages |
+| `get_updates_buf` | `string` | Cursor to send in the next request |
+| `longpolling_timeout_ms` | `number` | Optional server-suggested timeout in milliseconds |
+
+`sync_buf` is retained only for compatibility with older implementations. New integrations should use `get_updates_buf`.
+
+### `sendMessage`
+
+```http
+POST /ilink/bot/sendmessage
+```
+
+Request:
+
+```json
+{
+  "msg": {
+    "to_user_id": "<target user id>",
+    "context_token": "<conversation context token>",
+    "item_list": [
+      {
+        "type": 1,
+        "text_item": { "text": "Hello" }
+      }
+    ]
+  },
+  "base_info": {
+    "channel_version": "2.4.8",
+    "bot_agent": "OpenClaw"
+  }
+}
+```
+
+Response:
+
+```json
+{
+  "ret": 0,
+  "errmsg": ""
+}
+```
+
+The `context_token` received with an inbound message must be passed back when the reply belongs to that conversation.
+
+### `getUploadUrl`
+
+```http
+POST /ilink/bot/getuploadurl
+```
+
+Request:
+
+```json
+{
+  "filekey": "<client-generated file key>",
+  "media_type": 1,
+  "to_user_id": "<target user id>",
+  "rawsize": 12345,
+  "rawfilemd5": "<plaintext md5>",
+  "filesize": 12352,
+  "no_need_thumb": true,
+  "aeskey": "<16-byte key as hex>",
+  "base_info": {
+    "channel_version": "2.4.8",
+    "bot_agent": "OpenClaw"
+  }
+}
+```
+
+| Field | Type | Description |
+| --- | --- | --- |
+| `media_type` | `number` | `1` image, `2` video, `3` file, `4` voice |
+| `rawsize` | `number` | Plaintext size in bytes |
+| `rawfilemd5` | `string` | Plaintext MD5 |
+| `filesize` | `number` | Ciphertext size after AES-128-ECB with PKCS#7 padding |
+| `thumb_rawsize` | `number` | Thumbnail plaintext size when needed |
+| `thumb_rawfilemd5` | `string` | Thumbnail plaintext MD5 when needed |
+| `thumb_filesize` | `number` | Thumbnail ciphertext size when needed |
+| `no_need_thumb` | `boolean` | Set when no thumbnail upload is needed |
+| `aeskey` | `string` | AES key as a hexadecimal string |
+
+Response:
+
+```json
+{
+  "upload_param": "<encrypted upload parameter>",
+  "thumb_upload_param": "<encrypted thumbnail parameter>",
+  "upload_full_url": "<optional complete upload URL>"
+}
+```
+
+The client prefers `upload_full_url`. If it is absent, it constructs a CDN upload URL from `upload_param` and `filekey`.
+
+### `getConfig`
+
+```http
+POST /ilink/bot/getconfig
+```
+
+Request:
+
+```json
+{
+  "ilink_user_id": "<user id>",
+  "context_token": "<optional conversation context token>",
+  "base_info": {
+    "channel_version": "2.4.8",
+    "bot_agent": "OpenClaw"
+  }
+}
+```
+
+Response:
+
+```json
+{
+  "ret": 0,
+  "typing_ticket": "<base64 typing ticket>"
+}
+```
+
+### `sendTyping`
+
+```http
+POST /ilink/bot/sendtyping
+```
+
+Request:
+
+```json
+{
+  "ilink_user_id": "<user id>",
+  "typing_ticket": "<ticket from getConfig>",
+  "status": 1,
+  "base_info": {
+    "channel_version": "2.4.8",
+    "bot_agent": "OpenClaw"
+  }
+}
+```
+
+`status` is `1` for typing and `2` for cancel typing.
+
+### `notifyStart` and `notifyStop`
+
+```http
+POST /ilink/bot/msg/notifystart
+POST /ilink/bot/msg/notifystop
+```
+
+Request:
+
+```json
+{
+  "base_info": {
+    "channel_version": "2.4.8",
+    "bot_agent": "OpenClaw"
+  }
+}
+```
+
+Response:
+
+```json
+{
+  "ret": 0,
+  "errmsg": ""
+}
+```
+
+The plugin sends `notifyStart` when a channel client starts and `notifyStop` when it stops.
+
+## Message model
+
+### `WeixinMessage`
+
+| Field | Type | Description |
+| --- | --- | --- |
+| `seq` | `number` | Message sequence number |
+| `message_id` | `number` | Message ID |
+| `from_user_id` | `string` | Sender ID |
+| `to_user_id` | `string` | Receiver ID |
+| `client_id` | `string` | Client-generated or client-associated ID |
+| `create_time_ms` | `number` | Creation timestamp in milliseconds |
+| `update_time_ms` | `number` | Update timestamp in milliseconds |
+| `delete_time_ms` | `number` | Deletion timestamp in milliseconds |
+| `session_id` | `string` | Session ID |
+| `group_id` | `string` | Group ID when applicable |
+| `message_type` | `number` | `1` user, `2` bot |
+| `message_state` | `number` | `0` new, `1` generating, `2` finished |
+| `item_list` | `MessageItem[]` | Message content items |
+| `context_token` | `string` | Conversation context for replies |
+| `run_id` | `string` | Generation or run ID when applicable |
+
+### `MessageItem`
+
+| `type` | Content |
+| ---: | --- |
+| `1` | `text_item` |
+| `2` | `image_item` |
+| `3` | `voice_item` |
+| `4` | `file_item` |
+| `5` | `video_item` |
+| `11` | `tool_call_start_item` |
+| `12` | `tool_call_result_item` |
+
+Common item fields include `create_time_ms`, `update_time_ms`, `is_completed`, `msg_id`, and an optional `ref_msg` containing a referenced message item.
+
+`voice_item` may include a transcript in `text`. Media items can include a `media` object, and images and videos can additionally include `thumb_media`.
+
+### CDN media reference
+
+```json
+{
+  "encrypt_query_param": "<download parameter>",
+  "aes_key": "<base64 encoded AES key>",
+  "encrypt_type": 1,
+  "full_url": "<optional complete download URL>"
+}
+```
+
+The client prefers `full_url`. When a full URL is unavailable, a compatible deployment can construct a download URL as:
+
+```text
+<cdn_base_url>/download?encrypted_query_param=<url-encoded encrypt_query_param>
+```
+
+The AES key may be encoded as base64 of 16 raw bytes or as base64 of a 32-character hexadecimal key, depending on the media type.
+
+## CDN media flow
+
+### Upload
+
+1. Read the plaintext file and calculate its size and MD5.
+2. Generate a 16-byte AES key and a file key.
+3. Calculate the padded ciphertext size.
+4. Call `getUploadUrl`.
+5. Encrypt the content with AES-128-ECB and PKCS#7 padding.
+6. Send the encrypted bytes to the returned upload URL with `Content-Type: application/octet-stream`.
+7. Read the `x-encrypted-param` response header.
+8. Put the returned download parameter and AES key into the media reference sent through `sendMessage`.
+
+The current client uploads encrypted bytes with HTTP `POST`, not `PUT`. Image and video thumbnails follow the same flow when the backend requests them.
+
+### Download
+
+1. Read `full_url` or construct a compatible CDN download URL from `encrypt_query_param`.
+2. Download the bytes with HTTP `GET`.
+3. Decode the AES key from `aes_key` or the media-specific AES key field.
+4. Decrypt with AES-128-ECB and remove PKCS#7 padding.
+
+## Source references
+
+- [API request implementation](../src/api/api.ts)
+- [Protocol types](../src/api/types.ts)
+- [QR-code login flow](../src/auth/login-qr.ts)
+- [CDN upload implementation](../src/cdn/upload.ts)
+- [CDN encryption utilities](../src/cdn/aes-ecb.ts)

--- a/docs/protocol_zh_CN.md
+++ b/docs/protocol_zh_CN.md
@@ -2,7 +2,21 @@
 
 本文描述 `openclaw-weixin` 渠道插件使用的 HTTP JSON 协议，面向实现或对接兼容微信后端的开发者。普通用户只需阅读[项目 README](../README.zh_CN.md)。
 
-协议文档以 TypeScript 实现为事实来源。协议发生变化时，请同时检查 [`src/api/api.ts`](../src/api/api.ts)、[`src/api/types.ts`](../src/api/types.ts) 和 [`src/auth/login-qr.ts`](../src/auth/login-qr.ts)。
+[English](./protocol.md)
+
+## 阅读约定
+
+本文依据当前仓库的客户端代码编写，区分以下三类信息：
+
+- **字段与示例**：说明客户端类型和请求构造代码体现的数据格式。
+- **客户端行为**：说明当前插件实际发送、接受或重试的内容。
+- **接入建议**：为其他实现提供参考建议。
+
+客户端类型和行为不能代表完整的服务端契约。尤其是，TypeScript 字段标记为可选，不代表服务端一定接受省略该字段的请求；类型中定义了某个字段，也不代表插件已经实现所有相关能力。
+
+除非另有说明，JSON 示例用于展示部分字段，不代表经过验证的最小可用请求或完整响应。使用时需要替换占位符。`channel_version` 来自包元数据，示例中的 `2.4.8` 仅为示例值。
+
+源码依据：[`src/api/api.ts`](../src/api/api.ts)、[`src/api/types.ts`](../src/api/types.ts) 和 [`src/auth/login-qr.ts`](../src/auth/login-qr.ts)。超出这些源码所体现范围的服务端要求，需要另行验证。
 
 ## 协议范围和传输方式
 
@@ -31,7 +45,7 @@
 | `iLink-App-ClientVersion` | 插件版本按 `0x00MMNNPP` 编码后转成十进制字符串 |
 | `SKRouteTag` | 可选，由部署配置的路由标签 |
 
-二维码状态轮询使用公共应用请求头，但不使用 Bot token。获取二维码的请求同样不需要鉴权。
+客户端行为：二维码状态轮询发送应用请求头（`iLink-App-Id`、`iLink-App-ClientVersion` 和可选的 `SKRouteTag`），不添加 `AuthorizationType`、`Authorization` 或 `X-WECHAT-UIN`。获取二维码的 POST 请求使用 JSON POST 请求头，包括 `AuthorizationType` 和 `X-WECHAT-UIN`，但不携带 `Authorization` 和 `base_info`。
 
 ### `base_info`
 
@@ -48,13 +62,26 @@
 
 `channel_version` 是插件版本。`bot_agent` 是通过 `channels.openclaw-weixin.botAgent` 配置、经过清洗的观测标识，仅用于日志和监控归因，不参与鉴权或路由。
 
+客户端行为：`buildBaseInfo()` 总是填充这两个字段。`bot_agent` 默认为 `OpenClaw`。自定义值采用 ASCII `Name/Version` token，可附带注释，清洗后最多 256 字节。不合法的 token 会被丢弃，结果为空时回退到 `OpenClaw`。插件实例中的各账号共享该声明。
+
 ### 返回值和错误
 
-成功的 JSON 响应通常使用 `ret: 0`。当响应包含非零 `ret` 或 `errcode` 时，应结合 `errmsg` 判断是否重试或报告错误。
+响应类型中包含 `ret`、`errcode`、`errmsg` 等字段，但并非每个接口都包含这些字段。使用 `ret` 的响应以 `ret: 0` 表示成功。
 
-- HTTP 错误属于传输层失败，应与应用层 `ret` 分开处理。
-- `getUpdates` 的客户端超时属于正常的长轮询控制流程，客户端会返回空消息列表并重试。
-- 错误响应和日志不得包含 Bot token、二维码值或其他凭证。
+当前客户端按接口分别处理：
+
+| 接口 | 业务响应处理 |
+| --- | --- |
+| `getUpdates` | monitor 检查非零 `ret` 或 `errcode`。任一字段为 `-14` 时触发一小时的账号会话暂停；其他失败按照 monitor 的重试和退避逻辑处理。 |
+| `sendMessage` | 非零 `ret` 抛出错误；缺少 `ret` 不触发该检查。 |
+| `getUploadUrl` | 上传调用方要求非空的 `upload_full_url` 或 `upload_param`，不显式检查 `ret`。 |
+| `getConfig` | 缓存层只在 `ret === 0` 时接受配置；失败时使用缓存或默认配置，并安排再次尝试。 |
+| `sendTyping` | 包装函数不解析响应体，也不检查其中的业务返回码。 |
+| `notifyStart` / `notifyStop` | 渠道生命周期处理函数对非零 `ret` 或请求失败记录警告，不阻断启动或停止。 |
+
+JSON fetch 包装函数会在 HTTP 状态不成功时抛出错误。`getUpdates` 将超时或外部取消转换为空结果；外部取消用于让 monitor 退出，而非继续轮询。二维码状态轮询将请求失败转换为 `wait`。
+
+接入建议：分别处理 HTTP 状态和业务返回码，按接口定义重试策略，并对诊断输出中的凭证做脱敏。这些是建议，不表示当前客户端具有统一的错误处理或脱敏策略。
 
 ## 二维码登录
 
@@ -68,7 +95,7 @@ POST /ilink/bot/get_bot_qrcode?bot_type=3
 
 ```json
 {
-  "local_token_list": ["<之前获取的 token>" ]
+  "local_token_list": []
 }
 ```
 
@@ -176,7 +203,7 @@ POST /ilink/bot/getupdates
 | `get_updates_buf` | `string` | 下次请求需要回传的游标 |
 | `longpolling_timeout_ms` | `number` | 服务端建议的下次超时时间，单位为 ms |
 
-`sync_buf` 仅为兼容旧实现保留，新接入应使用 `get_updates_buf`。
+`sync_buf` 在 TypeScript 类型中保留并标记为废弃。当前请求构造只发送 `get_updates_buf`，monitor 也不会回退读取响应中的 `sync_buf`。只有返回的 `get_updates_buf` 非空时，才保存并更新游标。
 
 ### `sendMessage`
 
@@ -184,12 +211,16 @@ POST /ilink/bot/getupdates
 POST /ilink/bot/sendmessage
 ```
 
-请求：
+以下示例对应当前文本消息构造器在存在上下文令牌时的请求（传入 `run_id` 时还会携带该字段）：
 
 ```json
 {
   "msg": {
+    "from_user_id": "",
     "to_user_id": "<目标用户 ID>",
+    "client_id": "<客户端生成的 ID>",
+    "message_type": 2,
+    "message_state": 2,
     "context_token": "<会话上下文令牌>",
     "item_list": [
       {
@@ -214,7 +245,7 @@ POST /ilink/bot/sendmessage
 }
 ```
 
-如果回复属于某条入站消息对应的会话，必须把入站消息中的 `context_token` 回传。
+接入建议：回复对应会话时回传入站消息中的 `context_token`。客户端行为：发送函数在缺少令牌时记录警告并继续发送，这不能证明服务端一定接受该请求。当前媒体发送流程将说明文本和媒体内容拆成独立请求，每个请求有独立的 `client_id`。
 
 ### `getUploadUrl`
 
@@ -264,6 +295,8 @@ POST /ilink/bot/getuploadurl
 ```
 
 客户端优先使用 `upload_full_url`。如果没有该字段，则根据 `upload_param` 和 `filekey` 构造 CDN 上传 URL。
+
+类型定义包含缩略图请求字段和 `thumb_upload_param`。当前客户端行为：公共上传流程固定发送 `no_need_thumb: true`，只上传原文件，不消费 `thumb_upload_param`。这些字段不表示缩略图上传能力已经实现。同样，类型中定义了 `media_type: 4`，但当前文件发送流程只选择图片、视频或文件上传。
 
 ### `getConfig`
 
@@ -346,6 +379,8 @@ POST /ilink/bot/msg/notifystop
 
 ## 消息模型
 
+以下表格概述客户端类型。TypeScript 定义中，`WeixinMessage`、`MessageItem` 和媒体对象的属性均为可选；表格不声明服务端必填字段。`group_id` 等字段只表示类型定义包含该字段，不保证插件支持对应功能。
+
 ### `WeixinMessage`
 
 | 字段 | 类型 | 说明 |
@@ -382,6 +417,21 @@ POST /ilink/bot/msg/notifystop
 
 `voice_item` 可以在 `text` 中携带语音转写文本。媒体消息可以包含 `media`，图片和视频还可以包含 `thumb_media`。
 
+### 客户端使用的媒体字段
+
+| 字段 | 类型 | 当前用途 |
+| --- | --- | --- |
+| `image_item.aeskey` | `string` | 入站 AES 密钥，32 位十六进制字符串，优先于 `media.aes_key`。 |
+| `image_item.mid_size` | `number` | 图片发送器填入的密文字节数。 |
+| `video_item.video_size` | `number` | 视频发送器填入的密文字节数。 |
+| `file_item.file_name` | `string` | 附件文件名。 |
+| `file_item.len` | `string` | 文件发送器填入的明文字节数，编码为十进制字符串。 |
+| `voice_item.text` | `string` | 存在时表示语音转写文本。 |
+| `voice_item.encode_type` | `number` | 类型定义中的编码标识，不代表客户端能解码其中所有格式。 |
+| `voice_item.sample_rate` / `playtime` | `number` | 采样率（Hz）/ 时长（毫秒）。 |
+
+其他字段见[协议类型](../src/api/types.ts)，出站消息的构造见[消息发送实现](../src/messaging/send.ts)。
+
 ### CDN 媒体引用
 
 ```json
@@ -399,7 +449,7 @@ POST /ilink/bot/msg/notifystop
 <cdn_base_url>/download?encrypted_query_param=<URL 编码后的 encrypt_query_param>
 ```
 
-根据媒体类型不同，`aes_key` 可能是 16 字节原始密钥的 base64 编码，也可能是 32 位十六进制密钥字符串的 base64 编码。
+下载解码器接受两种形式：16 字节原始密钥的 base64 编码，或 32 位十六进制密钥字符串的 base64 编码。当前图片、视频和文件发送器均对十六进制密钥字符串进行 base64 编码。这分别描述接收兼容范围和实际发送行为，不表示各媒体类型必须使用不同编码。
 
 ## CDN 媒体流程
 
@@ -414,14 +464,16 @@ POST /ilink/bot/msg/notifystop
 7. 读取响应头中的 `x-encrypted-param`。
 8. 将下载参数和 AES 密钥放入媒体引用，再通过 `sendMessage` 发送。
 
-当前客户端使用 HTTP `POST` 上传密文，不是 `PUT`。如果后端要求缩略图，图片和视频缩略图也遵循相同流程。
+当前客户端行为：使用 HTTP `POST` 上传，固定传入 `no_need_thumb: true`，只上传原文件，没有缩略图上传步骤。
+
+上传成功必须同时满足 HTTP 状态为 `200`、响应头 `x-encrypted-param` 非空。HTTP 4xx 立即终止；其他失败（包括缺少该响应头）最多尝试三次。这是当前插件的成功判定和重试策略。
 
 ### 下载
 
-1. 使用 `full_url`，或根据 `encrypt_query_param` 构造兼容的 CDN 下载地址。
-2. 使用 HTTP `GET` 下载密文。
-3. 从 `aes_key` 或媒体专用的 AES key 字段解码 AES 密钥。
-4. 使用 AES-128-ECB 解密并移除 PKCS#7 填充。
+1. 优先使用 `full_url`。当前客户端启用了 URL 回退，缺少完整 URL 时根据 `encrypt_query_param` 构造 CDN 下载地址。
+2. 使用 HTTP `GET` 下载文件字节。
+3. 图片优先使用 `image_item.aeskey` 中的十六进制密钥，其次使用 `image_item.media.aes_key`。两者都不存在时，直接将下载内容作为明文图片使用。
+4. 对加密图片、语音、文件和视频，解码密钥后使用 AES-128-ECB 和 PKCS#7 填充解密。当前媒体下载器会跳过缺少 `media.aes_key` 的语音、文件和视频。
 
 ## 源码索引
 
@@ -430,3 +482,9 @@ POST /ilink/bot/msg/notifystop
 - [二维码登录流程](../src/auth/login-qr.ts)
 - [CDN 上传实现](../src/cdn/upload.ts)
 - [CDN 加密工具](../src/cdn/aes-ecb.ts)
+- [消息发送实现](../src/messaging/send.ts)
+- [入站媒体处理](../src/media/media-download.ts)
+- [CDN 上传传输](../src/cdn/cdn-upload.ts)
+- [消息轮询与重试](../src/monitor/monitor.ts)
+- [配置缓存](../src/api/config-cache.ts)
+- [渠道生命周期](../src/channel.ts)

--- a/docs/protocol_zh_CN.md
+++ b/docs/protocol_zh_CN.md
@@ -1,0 +1,432 @@
+# 微信后端 API 协议
+
+本文描述 `openclaw-weixin` 渠道插件使用的 HTTP JSON 协议，面向实现或对接兼容微信后端的开发者。普通用户只需阅读[项目 README](../README.zh_CN.md)。
+
+协议文档以 TypeScript 实现为事实来源。协议发生变化时，请同时检查 [`src/api/api.ts`](../src/api/api.ts)、[`src/api/types.ts`](../src/api/types.ts) 和 [`src/auth/login-qr.ts`](../src/auth/login-qr.ts)。
+
+## 协议范围和传输方式
+
+- API 使用 HTTPS 传输 JSON。
+- API 路径相对于当前 API base URL。
+- 普通 API 使用 `POST`；二维码状态轮询使用 `GET`。
+- JSON 中的 bytes 字段使用 base64 字符串表示。
+- 默认 API 地址为 `https://ilinkai.weixin.qq.com`。
+- 默认 CDN 地址为 `https://novac2c.cdn.weixin.qq.com/c2c`。
+
+二维码登录从固定 API 地址开始。服务端返回重定向信息后，客户端可能切换到返回的地址继续轮询二维码状态。媒体 CDN 如果由服务端直接返回完整 URL，客户端优先使用该 URL；否则再根据配置的 CDN 地址构造 URL。
+
+## 鉴权和公共元数据
+
+### 请求头
+
+插件会在适用的请求中添加以下请求头：
+
+| Header | 值 |
+| --- | --- |
+| `Content-Type` | JSON POST 请求使用 `application/json` |
+| `AuthorizationType` | `ilink_bot_token` |
+| `Authorization` | 鉴权 Bot API 使用 `Bearer <bot_token>` |
+| `X-WECHAT-UIN` | 随机 uint32 的十进制字符串再进行 base64 编码 |
+| `iLink-App-Id` | 插件应用 ID，目前为 `bot` |
+| `iLink-App-ClientVersion` | 插件版本按 `0x00MMNNPP` 编码后转成十进制字符串 |
+| `SKRouteTag` | 可选，由部署配置的路由标签 |
+
+二维码状态轮询使用公共应用请求头，但不使用 Bot token。获取二维码的请求同样不需要鉴权。
+
+### `base_info`
+
+鉴权 Bot POST 请求会携带 `base_info`：
+
+```json
+{
+  "base_info": {
+    "channel_version": "2.4.8",
+    "bot_agent": "OpenClaw"
+  }
+}
+```
+
+`channel_version` 是插件版本。`bot_agent` 是通过 `channels.openclaw-weixin.botAgent` 配置、经过清洗的观测标识，仅用于日志和监控归因，不参与鉴权或路由。
+
+### 返回值和错误
+
+成功的 JSON 响应通常使用 `ret: 0`。当响应包含非零 `ret` 或 `errcode` 时，应结合 `errmsg` 判断是否重试或报告错误。
+
+- HTTP 错误属于传输层失败，应与应用层 `ret` 分开处理。
+- `getUpdates` 的客户端超时属于正常的长轮询控制流程，客户端会返回空消息列表并重试。
+- 错误响应和日志不得包含 Bot token、二维码值或其他凭证。
+
+## 二维码登录
+
+### 获取二维码
+
+```http
+POST /ilink/bot/get_bot_qrcode?bot_type=3
+```
+
+请求体：
+
+```json
+{
+  "local_token_list": ["<之前获取的 token>" ]
+}
+```
+
+`local_token_list` 可以为空。客户端最多发送本地保存的最近 10 个 Bot token。
+
+响应体：
+
+```json
+{
+  "qrcode": "<二维码值>",
+  "qrcode_img_content": "<用于展示二维码的 URL 或内容>"
+}
+```
+
+### 轮询二维码状态
+
+```http
+GET /ilink/bot/get_qrcode_status?qrcode=<编码后的二维码值>
+```
+
+服务端要求验证时，客户端会追加：
+
+```http
+GET /ilink/bot/get_qrcode_status?qrcode=<编码后的二维码值>&verify_code=<编码后的验证码>
+```
+
+响应体：
+
+```json
+{
+  "status": "confirmed",
+  "bot_token": "<Bot token>",
+  "ilink_bot_id": "<Bot 账号 ID>",
+  "baseurl": "https://<API 地址>",
+  "ilink_user_id": "<扫码用户 ID>"
+}
+```
+
+客户端处理以下状态：
+
+| 状态 | 含义 |
+| --- | --- |
+| `wait` | 等待扫码或状态变化 |
+| `scaned` | 已扫码，继续验证 |
+| `confirmed` | 登录成功，可以保存凭证 |
+| `expired` | 二维码过期，可以刷新 |
+| `need_verifycode` | 需要输入手机上显示的验证码 |
+| `verify_code_blocked` | 验证失败次数过多，需要刷新或停止 |
+| `scaned_but_redirect` | 存在 `redirect_host` 时切换地址继续轮询 |
+| `binded_redirect` | Bot 已经绑定到当前 OpenClaw 实例 |
+
+## Bot API
+
+### 接口总览
+
+| 操作 | 方法和路径 | 用途 |
+| --- | --- | --- |
+| `getUpdates` | `POST /ilink/bot/getupdates` | 长轮询获取新消息 |
+| `getUploadUrl` | `POST /ilink/bot/getuploadurl` | 获取媒体上传参数 |
+| `sendMessage` | `POST /ilink/bot/sendmessage` | 发送消息 |
+| `getConfig` | `POST /ilink/bot/getconfig` | 获取账号配置和 typing ticket |
+| `sendTyping` | `POST /ilink/bot/sendtyping` | 设置或取消输入状态 |
+| `notifyStart` | `POST /ilink/bot/msg/notifystart` | 通知后端客户端启动 |
+| `notifyStop` | `POST /ilink/bot/msg/notifystop` | 通知后端客户端停止 |
+
+本节接口默认都携带公共请求头、Bot 鉴权和 `base_info`。
+
+### `getUpdates`
+
+```http
+POST /ilink/bot/getupdates
+```
+
+请求：
+
+```json
+{
+  "get_updates_buf": "",
+  "base_info": {
+    "channel_version": "2.4.8",
+    "bot_agent": "OpenClaw"
+  }
+}
+```
+
+客户端会把上次响应中的 `get_updates_buf` 传回。首次请求或游标重置时传空字符串。服务端应在有消息或长轮询超时后返回。
+
+响应：
+
+```json
+{
+  "ret": 0,
+  "msgs": [],
+  "get_updates_buf": "<下次请求使用的游标>",
+  "longpolling_timeout_ms": 35000
+}
+```
+
+| 字段 | 类型 | 说明 |
+| --- | --- | --- |
+| `ret` | `number` | `0` 表示成功 |
+| `errcode` | `number` | 可选的应用错误码 |
+| `errmsg` | `string` | 可选的错误描述 |
+| `msgs` | `WeixinMessage[]` | 收到的消息 |
+| `get_updates_buf` | `string` | 下次请求需要回传的游标 |
+| `longpolling_timeout_ms` | `number` | 服务端建议的下次超时时间，单位为 ms |
+
+`sync_buf` 仅为兼容旧实现保留，新接入应使用 `get_updates_buf`。
+
+### `sendMessage`
+
+```http
+POST /ilink/bot/sendmessage
+```
+
+请求：
+
+```json
+{
+  "msg": {
+    "to_user_id": "<目标用户 ID>",
+    "context_token": "<会话上下文令牌>",
+    "item_list": [
+      {
+        "type": 1,
+        "text_item": { "text": "你好" }
+      }
+    ]
+  },
+  "base_info": {
+    "channel_version": "2.4.8",
+    "bot_agent": "OpenClaw"
+  }
+}
+```
+
+响应：
+
+```json
+{
+  "ret": 0,
+  "errmsg": ""
+}
+```
+
+如果回复属于某条入站消息对应的会话，必须把入站消息中的 `context_token` 回传。
+
+### `getUploadUrl`
+
+```http
+POST /ilink/bot/getuploadurl
+```
+
+请求：
+
+```json
+{
+  "filekey": "<客户端生成的文件 key>",
+  "media_type": 1,
+  "to_user_id": "<目标用户 ID>",
+  "rawsize": 12345,
+  "rawfilemd5": "<明文 MD5>",
+  "filesize": 12352,
+  "no_need_thumb": true,
+  "aeskey": "<16 字节密钥的十六进制字符串>",
+  "base_info": {
+    "channel_version": "2.4.8",
+    "bot_agent": "OpenClaw"
+  }
+}
+```
+
+| 字段 | 类型 | 说明 |
+| --- | --- | --- |
+| `media_type` | `number` | `1` 图片、`2` 视频、`3` 文件、`4` 语音 |
+| `rawsize` | `number` | 明文大小，单位为字节 |
+| `rawfilemd5` | `string` | 明文 MD5 |
+| `filesize` | `number` | AES-128-ECB 加 PKCS#7 填充后的密文大小 |
+| `thumb_rawsize` | `number` | 需要缩略图时的明文大小 |
+| `thumb_rawfilemd5` | `string` | 需要缩略图时的明文 MD5 |
+| `thumb_filesize` | `number` | 需要缩略图时的密文大小 |
+| `no_need_thumb` | `boolean` | 不需要上传缩略图时设置 |
+| `aeskey` | `string` | 十六进制形式的 AES 密钥 |
+
+响应：
+
+```json
+{
+  "upload_param": "<加密上传参数>",
+  "thumb_upload_param": "<加密缩略图参数>",
+  "upload_full_url": "<可选的完整上传 URL>"
+}
+```
+
+客户端优先使用 `upload_full_url`。如果没有该字段，则根据 `upload_param` 和 `filekey` 构造 CDN 上传 URL。
+
+### `getConfig`
+
+```http
+POST /ilink/bot/getconfig
+```
+
+请求：
+
+```json
+{
+  "ilink_user_id": "<用户 ID>",
+  "context_token": "<可选，会话上下文令牌>",
+  "base_info": {
+    "channel_version": "2.4.8",
+    "bot_agent": "OpenClaw"
+  }
+}
+```
+
+响应：
+
+```json
+{
+  "ret": 0,
+  "typing_ticket": "<base64 编码的 typing ticket>"
+}
+```
+
+### `sendTyping`
+
+```http
+POST /ilink/bot/sendtyping
+```
+
+请求：
+
+```json
+{
+  "ilink_user_id": "<用户 ID>",
+  "typing_ticket": "<从 getConfig 获取的 ticket>",
+  "status": 1,
+  "base_info": {
+    "channel_version": "2.4.8",
+    "bot_agent": "OpenClaw"
+  }
+}
+```
+
+`status` 为 `1` 表示正在输入，`2` 表示取消输入。
+
+### `notifyStart` 和 `notifyStop`
+
+```http
+POST /ilink/bot/msg/notifystart
+POST /ilink/bot/msg/notifystop
+```
+
+请求：
+
+```json
+{
+  "base_info": {
+    "channel_version": "2.4.8",
+    "bot_agent": "OpenClaw"
+  }
+}
+```
+
+响应：
+
+```json
+{
+  "ret": 0,
+  "errmsg": ""
+}
+```
+
+渠道客户端启动时发送 `notifyStart`，停止时发送 `notifyStop`。
+
+## 消息模型
+
+### `WeixinMessage`
+
+| 字段 | 类型 | 说明 |
+| --- | --- | --- |
+| `seq` | `number` | 消息序列号 |
+| `message_id` | `number` | 消息 ID |
+| `from_user_id` | `string` | 发送者 ID |
+| `to_user_id` | `string` | 接收者 ID |
+| `client_id` | `string` | 客户端生成或关联的 ID |
+| `create_time_ms` | `number` | 创建时间戳，单位为 ms |
+| `update_time_ms` | `number` | 更新时间戳，单位为 ms |
+| `delete_time_ms` | `number` | 删除时间戳，单位为 ms |
+| `session_id` | `string` | 会话 ID |
+| `group_id` | `string` | 适用于群聊的群 ID |
+| `message_type` | `number` | `1` 用户、`2` Bot |
+| `message_state` | `number` | `0` 新消息、`1` 生成中、`2` 完成 |
+| `item_list` | `MessageItem[]` | 消息内容列表 |
+| `context_token` | `string` | 回复时使用的会话上下文 |
+| `run_id` | `string` | 适用时的生成或运行 ID |
+
+### `MessageItem`
+
+| `type` | 内容 |
+| ---: | --- |
+| `1` | `text_item` |
+| `2` | `image_item` |
+| `3` | `voice_item` |
+| `4` | `file_item` |
+| `5` | `video_item` |
+| `11` | `tool_call_start_item` |
+| `12` | `tool_call_result_item` |
+
+公共字段包括 `create_time_ms`、`update_time_ms`、`is_completed`、`msg_id`，以及可选的 `ref_msg`。`ref_msg` 用于表示被引用的消息内容。
+
+`voice_item` 可以在 `text` 中携带语音转写文本。媒体消息可以包含 `media`，图片和视频还可以包含 `thumb_media`。
+
+### CDN 媒体引用
+
+```json
+{
+  "encrypt_query_param": "<下载参数>",
+  "aes_key": "<base64 编码的 AES 密钥>",
+  "encrypt_type": 1,
+  "full_url": "<可选的完整下载 URL>"
+}
+```
+
+客户端优先使用 `full_url`。如果没有完整 URL，兼容实现可以按以下形式构造下载地址：
+
+```text
+<cdn_base_url>/download?encrypted_query_param=<URL 编码后的 encrypt_query_param>
+```
+
+根据媒体类型不同，`aes_key` 可能是 16 字节原始密钥的 base64 编码，也可能是 32 位十六进制密钥字符串的 base64 编码。
+
+## CDN 媒体流程
+
+### 上传
+
+1. 读取明文文件，计算大小和 MD5。
+2. 生成 16 字节 AES 密钥和 file key。
+3. 计算填充后的密文大小。
+4. 调用 `getUploadUrl`。
+5. 使用 AES-128-ECB 和 PKCS#7 填充加密文件内容。
+6. 使用 `Content-Type: application/octet-stream` 将密文发送到返回的上传 URL。
+7. 读取响应头中的 `x-encrypted-param`。
+8. 将下载参数和 AES 密钥放入媒体引用，再通过 `sendMessage` 发送。
+
+当前客户端使用 HTTP `POST` 上传密文，不是 `PUT`。如果后端要求缩略图，图片和视频缩略图也遵循相同流程。
+
+### 下载
+
+1. 使用 `full_url`，或根据 `encrypt_query_param` 构造兼容的 CDN 下载地址。
+2. 使用 HTTP `GET` 下载密文。
+3. 从 `aes_key` 或媒体专用的 AES key 字段解码 AES 密钥。
+4. 使用 AES-128-ECB 解密并移除 PKCS#7 填充。
+
+## 源码索引
+
+- [API 请求实现](../src/api/api.ts)
+- [协议类型定义](../src/api/types.ts)
+- [二维码登录流程](../src/auth/login-qr.ts)
+- [CDN 上传实现](../src/cdn/upload.ts)
+- [CDN 加密工具](../src/cdn/aes-ecb.ts)


### PR DESCRIPTION
## Summary

The READMEs mix installation and configuration instructions with detailed backend protocol content. This change reorganizes the English and Chinese READMEs around setup, configuration, troubleshooting, and contribution, and moves the protocol reference into dedicated bilingual documents.

- Add docs/protocol.md and docs/protocol_zh_CN.md covering QR login, messaging, lifecycle notifications, and CDN media handling.
- Distinguish client behavior, field definitions, and integration guidance; clarify thumbnail handling, plaintext image downloads, message examples, and per-endpoint error handling against the current source.
- Add documentation navigation and explain the existing difference between the runtime version guard and the npm peer dependency requirement.

Only Markdown files change.

## Validation

- Relative links, JSON examples, code fences, bilingual heading/example structures, and git diff --check passed.
- npm ci --ignore-scripts and local quality checks (format, lint, typecheck, unit tests, build) passed during the README reorganization.
- npm test passed: 403 tests; branch coverage 90.04%.
- Subsequent protocol-only revisions passed document validation. Existing lint warnings and dependency audit findings remain unchanged.
