### PR TITLE
fix(messaging): final-only delivery for WeChat interim block text (#292)

### DIFF
--- a/src/messaging/interim-reply-policy.test.ts
+++ b/src/messaging/interim-reply-policy.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from "vitest";
+
+import { isInterimTextOnlyWeixinReply } from "./interim-reply-policy.js";
+
+describe("isInterimTextOnlyWeixinReply", () => {
+  it("skips block-streamed commentary text (interim narration between tool calls)", () => {
+    expect(
+      isInterimTextOnlyWeixinReply({ text: "我先查一下你的订单状态" }, { kind: "block" }),
+    ).toBe(true);
+  });
+
+  it("keeps the final reply text", () => {
+    expect(isInterimTextOnlyWeixinReply({ text: "这是最终回复" }, { kind: "final" })).toBe(false);
+  });
+
+  it("keeps every final payload when the reply is split across multiple messages", () => {
+    expect(isInterimTextOnlyWeixinReply({ text: "第一条" }, { kind: "final" })).toBe(false);
+    expect(isInterimTextOnlyWeixinReply({ text: "第二条" }, { kind: "final" })).toBe(false);
+  });
+
+  it("keeps tool-summary text (tool output is never re-merged into the final reply)", () => {
+    expect(isInterimTextOnlyWeixinReply({ text: "查询到订单 3 条" }, { kind: "tool" })).toBe(false);
+  });
+
+  it("keeps interim payloads that carry media alongside text", () => {
+    expect(
+      isInterimTextOnlyWeixinReply(
+        { text: "图片如下", mediaUrl: "https://example.com/a.png" },
+        { kind: "block" },
+      ),
+    ).toBe(false);
+    expect(
+      isInterimTextOnlyWeixinReply(
+        { text: "多图如下", mediaUrls: ["https://example.com/a.png"] },
+        { kind: "tool" },
+      ),
+    ).toBe(false);
+  });
+
+  it("keeps interim payloads that carry a command-execution approval prompt", () => {
+    expect(
+      isInterimTextOnlyWeixinReply(
+        { text: "是否允许执行 rm -rf / ?", channelData: { execApproval: {} } },
+        { kind: "block" },
+      ),
+    ).toBe(false);
+  });
+
+  it("keeps interim error payloads so failures are not silently dropped", () => {
+    expect(
+      isInterimTextOnlyWeixinReply({ text: "工具调用失败", isError: true }, { kind: "block" }),
+    ).toBe(false);
+  });
+
+  it("keeps payloads whose delivery kind is unknown (defensive: legacy host)", () => {
+    expect(isInterimTextOnlyWeixinReply({ text: "不确定来源" }, undefined)).toBe(false);
+    expect(isInterimTextOnlyWeixinReply({ text: "不确定来源" })).toBe(false);
+  });
+
+  it("keeps empty and media-only interim payloads", () => {
+    expect(isInterimTextOnlyWeixinReply({}, { kind: "block" })).toBe(false);
+    expect(
+      isInterimTextOnlyWeixinReply({ mediaUrl: "https://example.com/a.png" }, { kind: "block" }),
+    ).toBe(false);
+  });
+});

--- a/src/messaging/interim-reply-policy.ts
+++ b/src/messaging/interim-reply-policy.ts
@@ -1,0 +1,26 @@
+import type { ReplyPayload, ReplyDispatchKind } from "openclaw/plugin-sdk/reply-runtime";
+
+/**
+ * WeChat messages cannot be edited or retracted after they are sent. Block
+ * commentary emitted between tool calls (assistant narration) is sent verbatim
+ * and then merged into the final reply again by the host, so the user would
+ * see the same content twice. WeChat therefore uses final-only delivery for
+ * these interim blocks: text-only block payloads are suppressed, while
+ * anything that is not re-merged into the final reply is still delivered
+ * (final payloads, media, errors, tool summaries, approval prompts).
+ */
+export function isInterimTextOnlyWeixinReply(
+  payload: ReplyPayload,
+  info?: { kind?: ReplyDispatchKind },
+): boolean {
+  if (info?.kind !== "block") return false;
+  if (!payload.text) return false;
+  if (payload.isError === true) return false;
+  if (payload.mediaUrl || (payload.mediaUrls?.length ?? 0) > 0) return false;
+  if (hasExecApprovalChannelData(payload)) return false;
+  return true;
+}
+
+function hasExecApprovalChannelData(payload: ReplyPayload): boolean {
+  return payload.channelData?.execApproval != null;
+}

--- a/src/messaging/process-message.ts
+++ b/src/messaging/process-message.ts
@@ -33,6 +33,7 @@ import type { WeixinInboundMediaOpts } from "./inbound.js";
 import { sendWeixinMediaFile } from "./send-media.js";
 import { StreamingMarkdownFilter } from "./markdown-filter.js";
 import { sendMessageWeixin } from "./send.js";
+import { isInterimTextOnlyWeixinReply } from "./interim-reply-policy.js";
 import { WeixinReplyProgressSender } from "./reply-progress-sender.js";
 import { handleSlashCommand } from "./slash-commands.js";
 
@@ -334,7 +335,13 @@ export async function processOneMessage(
     deps.channelRuntime.reply.createReplyDispatcherWithTyping({
       humanDelay,
       typingCallbacks,
-      deliver: async (payload) => {
+      deliver: async (payload, info) => {
+        if (isInterimTextOnlyWeixinReply(payload, info)) {
+          logger.debug(
+            `outbound: skipped interim text-only payload kind=${info?.kind} to=${ctx.To} textLen=${(payload.text ?? "").length}`,
+          );
+          return;
+        }
         const rawText = payload.text ?? "";
         let text = (() => {
           const f = new StreamingMarkdownFilter();


### PR DESCRIPTION
## 问题摘要

Issue #292：agent 在工具调用之间产出的中间文本（旁白/commentary）被逐条直发到微信，且同一段文本随后又并入最终回复重发。微信不能编辑消息，用户收到重复消息（实测 A / B / A(重复) / 8 两起同构）。

## 根因

1. 插件已向 `dispatchReplyFromConfig` 传 `disableBlockStreaming: true`，但工具调用之间的块级旁白（block）仍从宿主直达插件的 `deliver` 回调并外发；
2. 宿主最终 payload 去重（`directlySentBlockKeys` / `sentFinalPayloadDedupeKeys`）只登记 terminal 内容、排除 commentary，因此最终回复再把相同文本重发一遍 —— 重复源自宿主，按 issue 约定**本 PR 不改宿主**。

## 修复策略（插件侧，final-only 交付）

微信是不可编辑消息的通道，故对中间块文本采用 final-only 交付：在插件的 `deliver` 路径识别并跳过「非最终、纯文本」的 block payload，只保留会被并入最终回复的前置内容，避免同文双发。

- 新增 `src/messaging/interim-reply-policy.ts`：纯函数 `isInterimTextOnlyWeixinReply(payload, info)`，仅在交付种类为 `block`、且为纯文本时判定应跳过。
- `src/messaging/process-message.ts` 的 `deliver` 回调读取宿主导入的第二个参数 `{ kind }`，对判定命中的 payload 提前返回（debug 日志记录）。
- 严格不误伤：`final`（含合法的多条 final）、携带媒体（`mediaUrl`/`mediaUrls`）、`isError`、审批（`channelData.execApproval`）、tool 摘要、以及 kind 未知（防御旧宿主）一律照常发送。

## 测试说明

新增 `src/messaging/interim-reply-policy.test.ts`（9 例，vitest，co-located）：
- 跳过 block 纯文本（旁白）✔
- 保留 final / 多条 final ✔
- 保留媒体 block / tool ✔
- 保留审批（execApproval）block ✔
- 保留 isError ✔
- 保留 tool 摘要（tool 输出不会并入最终回复，删除会造成内容丢失）✔
- kind 未知（防御）与空/仅媒体 payload 保留 ✔

## 本地验证

`npm run ci` 全绿：oxfmt format:check + oxlint + tsc typecheck + vitest（28 文件 / 412 用例）+ build。oxlint 仅有既存告警（如 `process-message.ts:508`，位于基线未改动行），与本次改动无关。

Fixes #292
