### PR TITLE
fix(messaging): suppress NO_REPLY silent token on WeChat outbound

### DIFF
--- a/src/channel.ts
+++ b/src/channel.ts
@@ -41,6 +41,7 @@ import {
 } from "./messaging/outbound-hooks.js";
 import { sendWeixinMediaFile } from "./messaging/send-media.js";
 import { sendMessageWeixin, StreamingMarkdownFilter } from "./messaging/send.js";
+import { isSilentOutboundText } from "./messaging/silent-reply.js";
 import { downloadRemoteImageToTemp } from "./cdn/upload.js";
 
 /** Returns true when mediaUrl refers to a local filesystem path (absolute or relative). */
@@ -150,6 +151,11 @@ async function sendWeixinOutbound(params: {
     return { channel: "openclaw-weixin", messageId: "" };
   }
   filteredText = sendingResult.text;
+
+  if (isSilentOutboundText(filteredText)) {
+    aLog.info(`sendWeixinOutbound: suppressed silent reply token to=${params.to}`);
+    return { channel: "openclaw-weixin", messageId: "" };
+  }
 
   try {
     const result = await sendMessageWeixin({
@@ -304,6 +310,14 @@ export const weixinPlugin: ChannelPlugin<ResolvedWeixinAccount> = {
         return { channel: "openclaw-weixin", messageId: "" };
       }
       text = sendingResult.text;
+
+      if (isSilentOutboundText(text)) {
+        if (!(mediaUrl && (isLocalFilePath(mediaUrl) || isRemoteUrl(mediaUrl)))) {
+          aLog.info(`sendMedia: suppressed silent reply token to=${ctx.to}`);
+          return { channel: "openclaw-weixin", messageId: "" };
+        }
+        text = "";
+      }
 
       if (mediaUrl && (isLocalFilePath(mediaUrl) || isRemoteUrl(mediaUrl))) {
         let filePath: string;

--- a/src/messaging/process-message.ts
+++ b/src/messaging/process-message.ts
@@ -35,6 +35,7 @@ import type { WeixinInboundMediaOpts } from "./inbound.js";
 import { sendWeixinMediaFile } from "./send-media.js";
 import { StreamingMarkdownFilter } from "./markdown-filter.js";
 import { sendMessageWeixin } from "./send.js";
+import { isSilentOutboundText } from "./silent-reply.js";
 import { WeixinReplyProgressSender } from "./reply-progress-sender.js";
 import { getActiveQuoteMediaSubdir, getQuoteStore } from "./quote-store.js";
 import { handleSlashCommand } from "./slash-commands.js";
@@ -397,6 +398,15 @@ export async function processOneMessage(
           return;
         }
         text = sendingResult.text;
+
+        // OpenClaw silent token: skip text-only delivery; keep media if present.
+        if (isSilentOutboundText(text)) {
+          if (!mediaUrl) {
+            logger.info(`outbound: suppressed silent reply token to=${ctx.To}`);
+            return;
+          }
+          text = "";
+        }
 
         try {
           if (mediaUrl) {

--- a/src/messaging/send.test.ts
+++ b/src/messaging/send.test.ts
@@ -44,6 +44,36 @@ beforeEach(() => {
 });
 
 describe("sendMessageWeixin", () => {
+  it("suppresses NO_REPLY silent token without calling the API", async () => {
+    const result = await sendMessageWeixin({
+      to: "user1",
+      text: "NO_REPLY",
+      opts: { baseUrl: "https://api.com", contextToken: "ctx" },
+    });
+    expect(result.messageId).toBe("");
+    expect(mockSendMessageApi).not.toHaveBeenCalled();
+  });
+
+  it("suppresses case-insensitive no_reply silent token", async () => {
+    const result = await sendMessageWeixin({
+      to: "user1",
+      text: "no_reply",
+      opts: { baseUrl: "https://api.com", contextToken: "ctx" },
+    });
+    expect(result.messageId).toBe("");
+    expect(mockSendMessageApi).not.toHaveBeenCalled();
+  });
+
+  it("still delivers substantive text that mentions NO_REPLY inline", async () => {
+    mockSendMessageApi.mockResolvedValueOnce(undefined);
+    await sendMessageWeixin({
+      to: "user1",
+      text: "status: NO_REPLY is a token",
+      opts: { baseUrl: "https://api.com", contextToken: "ctx" },
+    });
+    expect(mockSendMessageApi).toHaveBeenCalledOnce();
+  });
+
   it("sends without contextToken (no throw)", async () => {
     mockSendMessageApi.mockResolvedValueOnce(undefined);
     const result = await sendMessageWeixin({

--- a/src/messaging/send.ts
+++ b/src/messaging/send.ts
@@ -1,4 +1,5 @@
 import type { ReplyPayload } from "openclaw/plugin-sdk/reply-runtime";
+import { isSilentOutboundText } from "./silent-reply.js";
 
 import { sendMessage as sendMessageApi } from "../api/api.js";
 import type { WeixinApiOptions } from "../api/api.js";
@@ -106,6 +107,10 @@ export async function sendMessageWeixin(params: {
   opts: WeixinMessageSendOptions;
 }): Promise<WeixinSendResult> {
   const { to, text, opts } = params;
+  if (isSilentOutboundText(text)) {
+    logger.info(`sendMessageWeixin: suppressed silent reply token to=${to}`);
+    return { messageId: "" };
+  }
   if (!opts.contextToken) {
     logger.warn(`sendMessageWeixin: contextToken missing for to=${to}, sending without context`);
   }

--- a/src/messaging/silent-reply.test.ts
+++ b/src/messaging/silent-reply.test.ts
@@ -1,0 +1,25 @@
+import { describe, it, expect } from "vitest";
+
+import { isSilentOutboundText } from "./silent-reply.js";
+
+describe("isSilentOutboundText", () => {
+  it("suppresses exact NO_REPLY token", () => {
+    expect(isSilentOutboundText("NO_REPLY")).toBe(true);
+  });
+
+  it("suppresses case-insensitive no_reply token", () => {
+    expect(isSilentOutboundText("no_reply")).toBe(true);
+    expect(isSilentOutboundText("No_Reply")).toBe(true);
+  });
+
+  it("suppresses whitespace-padded silent tokens", () => {
+    expect(isSilentOutboundText("  NO_REPLY  ")).toBe(true);
+  });
+
+  it("does not suppress empty or substantive text", () => {
+    expect(isSilentOutboundText("")).toBe(false);
+    expect(isSilentOutboundText(undefined)).toBe(false);
+    expect(isSilentOutboundText("hello")).toBe(false);
+    expect(isSilentOutboundText("Done.\n\nNO_REPLY")).toBe(false);
+  });
+});

--- a/src/messaging/silent-reply.ts
+++ b/src/messaging/silent-reply.ts
@@ -1,0 +1,13 @@
+import { isSilentReplyText } from "openclaw/plugin-sdk/reply-runtime";
+
+/**
+ * True when outbound text is an OpenClaw silent-reply token (`NO_REPLY` /
+ * `no_reply`, case-insensitive exact match) and must not be delivered as a
+ * user-visible WeChat message.
+ *
+ * Mirrors the host silent-token gate used on other OpenClaw delivery paths.
+ * Media-only deliveries should still proceed after clearing the silent text.
+ */
+export function isSilentOutboundText(text: string | undefined): boolean {
+  return isSilentReplyText(text);
+}


### PR DESCRIPTION
## Summary

- When a turn's final reply is the OpenClaw silent token `NO_REPLY` / `no_reply`, the WeChat outbound path was delivering the literal string as a real message (`textLen=8`).
- Gate outbound text with the host `isSilentReplyText` helper (via a thin `isSilentOutboundText` wrapper) so exact silent tokens are skipped before `sendMessage` / deliver / channel outbound.
- If media is present alongside a silent token, strip the token text and still deliver the media.

Fixes #293

## Changes

| File | Change |
|------|--------|
| `src/messaging/silent-reply.ts` | Wrapper around SDK `isSilentReplyText` |
| `src/messaging/send.ts` | Defense-in-depth skip in `sendMessageWeixin` |
| `src/messaging/process-message.ts` | Skip/strip in reply `deliver` callback |
| `src/channel.ts` | Skip/strip in `sendWeixinOutbound` / `sendMedia` |
| `src/messaging/silent-reply.test.ts` / `send.test.ts` | Unit coverage for suppress + non-suppress cases |

## Test plan

- [x] `npx vitest run --coverage=false src/messaging/silent-reply.test.ts src/messaging/send.test.ts` (29 passed)
- [x] `npx vitest run --coverage=false src/messaging` (273 passed)
- [x] `oxfmt --check` on touched files
- [ ] Live: heartbeat/background turn that ends with `NO_REPLY` no longer appears in WeChat chat
- [ ] Live: normal text replies still deliver
- [ ] Live: media + silent token still delivers media without the `NO_REPLY` caption